### PR TITLE
Fix: 修复了Windows预览体验版 Experimental 的 Future Platforms (老 Canary 频道，29xxx版本) 分支长期出现的启动软件后出现白屏的情况

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -26,7 +26,6 @@ import 'src/services/bt_file_selection_service.dart';
 import 'src/services/app_icon_service.dart';
 import 'src/services/log_service.dart';
 import 'src/services/notification_service.dart';
-import 'src/services/foreground_service.dart';
 import 'src/services/power_service.dart';
 import 'src/services/tray_service.dart';
 import 'src/i18n/locale_provider.dart';
@@ -36,6 +35,28 @@ import 'src/theme/flux_theme_tokens.dart';
 import 'src/theme/theme_provider.dart';
 import 'src/widgets/feedback_dialog.dart';
 import 'src/widgets/update_changelog_dialog.dart';
+
+// 防止整个应用卡死在白屏
+// 新增 _runStartupStep(...)，启动阶段的非关键步骤统一加超时保护和日志。
+Future<void> _runStartupStep(
+  String name,
+  Future<void> Function() action, {
+  Duration timeout = const Duration(seconds: 3),
+}) async {
+  final sw = Stopwatch()..start();
+  logInfo('startup', 'starting $name');
+  try {
+    await action().timeout(timeout);
+    logInfo('startup', 'completed $name in ${sw.elapsedMilliseconds}ms');
+  } catch (e, stack) {
+    logError(
+      'startup',
+      '$name failed after ${sw.elapsedMilliseconds}ms, continuing with defaults',
+      e,
+      stack,
+    );
+  }
+}
 
 Future<void> main(List<String> args) async {
   // 独立快速下载小窗引擎入口：原生宿主以 --quick-popup 参数启动第二引擎。
@@ -48,9 +69,15 @@ Future<void> main(List<String> args) async {
 
   WidgetsFlutterBinding.ensureInitialized();
 
+  // 初始化日志服务 — 必须尽早执行。
+  // 预览版 Windows 上若 SharedPreferences / 插件初始化卡住，
+  // 需要保证这些启动前故障也能写入日志，而不是只剩白屏。
+  LogService.instance.init();
+  logInfo('main', 'bootstrap start, args=$args');
+
   // 初始化 i18n — 创建 LocaleNotifier 并从 SharedPreferences 恢复语言偏好
   localeNotifier = LocaleNotifier();
-  await localeNotifier.init();
+  await _runStartupStep('locale init', () => localeNotifier.init());
 
   // 注：已移除 desktop_multi_window 子窗口入口。
   // 下载完成通知现在通过主窗口内 OverlayEntry 实现，
@@ -66,8 +93,6 @@ Future<void> main(List<String> args) async {
       .where((a) => a.toLowerCase().endsWith('.torrent'))
       .toList();
 
-  // 初始化日志服务 — 最先初始化，以捕获后续所有日志
-  LogService.instance.init();
   logInfo(
     'main',
     'FluxDown starting, args=$args, torrentFiles=${torrentFilePaths.length}',
@@ -94,14 +119,12 @@ Future<void> main(List<String> args) async {
   logInfo('main', 'initializing theme...');
   // 在 runApp 之前恢复主题设置，避免启动时主题闪烁
   final themeProvider = ThemeProvider();
-  await themeProvider.init();
-  logInfo('main', 'theme initialized');
+  await _runStartupStep('theme init', () => themeProvider.init());
+  logInfo('main', 'theme init step finished');
 
   // ===== 移动端启动流程 =====
   // Android / iOS 走精简初始化：无窗口管理、托盘、开机启动等桌面服务。
   if (Platform.isAndroid || Platform.isIOS) {
-    // 前台服务 ↔ 主 isolate 通信端口（必须在 runApp 之前）
-    ForegroundServiceManager.initCommunicationPort();
     logInfo('main', 'initializing Rust runtime (mobile)...');
     await initializeRust(assignRustSignal);
     logInfo('main', 'starting mobile shell');
@@ -119,7 +142,10 @@ Future<void> main(List<String> args) async {
 
   // 从 SharedPreferences 读取上次保存的窗口状态（纯读取，不调用 windowManager API）
   logInfo('main', 'loading saved window state...');
-  await WindowStateService.instance.loadState();
+  await _runStartupStep(
+    'load saved window state',
+    () => WindowStateService.instance.loadState(),
+  );
 
   // 不使用 waitUntilReadyToShow —— 它的回调参数类型是 VoidCallback，
   // async 回调中的 await 全部变成 fire-and-forget，与原生层 first_frame_cb
@@ -140,8 +166,11 @@ Future<void> main(List<String> args) async {
     await windowManager.setBackgroundColor(const Color(0xFFE5E5E5));
   }
   await windowManager.setMinimumSize(const Size(900, 500));
-  await WindowStateService.instance.applyState();
-  logInfo('main', 'window state applied before runApp');
+  await _runStartupStep(
+    'apply saved window state',
+    () => WindowStateService.instance.applyState(),
+  );
+  logInfo('main', 'window state apply step finished before runApp');
 
   // 初始化开机启动支持（注册时附带 --silentStart 参数，开机自启免打扰）
   // Windows 下路径加引号，防止含空格的安装路径（如 C:\Program Files\...）被 CreateProcess 截断解析失败。
@@ -185,8 +214,12 @@ Future<void> main(List<String> args) async {
 
   // 初始化系统托盘
   logInfo('main', 'initializing tray...');
-  await TrayService.instance.init();
-  logInfo('main', 'tray initialized');
+  await _runStartupStep(
+    'tray init',
+    () => TrayService.instance.init(),
+    timeout: const Duration(seconds: 5),
+  );
+  logInfo('main', 'tray init step finished');
 
   // themeProvider 已加载完毕，立即将托盘图标修正为 app 当前生效主题
   // （init() 默认使用系统亮度作为初始值，这里覆盖为 app 的显式设置）
@@ -202,14 +235,21 @@ Future<void> main(List<String> args) async {
           WidgetsBinding.instance.platformDispatcher.platformBrightness ==
           Brightness.dark;
     }
-    await TrayService.instance.setIsDark(trayIsDark);
+    await _runStartupStep(
+      'tray theme sync',
+      () => TrayService.instance.setIsDark(trayIsDark),
+    );
     logInfo('main', 'tray isDark=$trayIsDark (from app theme: $mode)');
   }
 
   // 恢复用户自定义的应用图标（窗口/任务栏/托盘）。
   // WM_SETICON 仅对当前进程生效，需每次启动重新应用；默认图标来自 exe 资源，无需处理。
-  await AppIconService.instance.init();
-  logInfo('main', 'app icon service initialized');
+  await _runStartupStep(
+    'app icon init',
+    () => AppIconService.instance.init(),
+    timeout: const Duration(seconds: 5),
+  );
+  logInfo('main', 'app icon init step finished');
 
   logInfo('main', 'initializing Rust runtime...');
   await initializeRust(assignRustSignal);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -36,8 +36,8 @@ import 'src/theme/theme_provider.dart';
 import 'src/widgets/feedback_dialog.dart';
 import 'src/widgets/update_changelog_dialog.dart';
 
-// 防止整个应用卡死在白屏
-// 新增 _runStartupStep(...)，启动阶段的非关键步骤统一加超时保护和日志。
+/// 启动阶段的非关键步骤统一加超时保护和日志，
+/// 防止某一步卡住导致整个应用白屏。
 Future<void> _runStartupStep(
   String name,
   Future<void> Function() action, {

--- a/lib/src/i18n/locale_provider.dart
+++ b/lib/src/i18n/locale_provider.dart
@@ -13,7 +13,7 @@ const _kAppLocale = 'app_locale';
 const kLocaleSystem = 'system';
 const kLocaleZh = 'zh';
 const kLocaleEn = 'en';
-const _kPrefsInitTimeout = Duration(seconds: 3); // 新增了3秒超时
+const _kPrefsInitTimeout = Duration(seconds: 3);
 
 /// 获取系统语言并决定使用的 locale。
 /// 支持 zh（中文）和 en（英文），其他语言默认使用英文。
@@ -45,7 +45,7 @@ class LocaleNotifier extends ChangeNotifier {
   S get s => currentS;
 
   /// 启动时调用，从 SharedPreferences 恢复语言偏好。
-  /// 给 LocaleNotifier.init() 里的 SharedPreferences.getInstance() 加了 3 秒超时， 超时或异常时记录日志，并回退到系统语言，而不是一直卡住启动。
+  /// 读取加 3 秒超时；超时或异常时记录日志并回退系统语言，避免卡住启动。
   Future<void> init() async {
     try {
       final prefs = await SharedPreferences.getInstance().timeout(

--- a/lib/src/i18n/locale_provider.dart
+++ b/lib/src/i18n/locale_provider.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/widgets.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import '../services/log_service.dart';
 export 'translations.dart';
 import 'translations.dart';
 
@@ -12,6 +13,7 @@ const _kAppLocale = 'app_locale';
 const kLocaleSystem = 'system';
 const kLocaleZh = 'zh';
 const kLocaleEn = 'en';
+const _kPrefsInitTimeout = Duration(seconds: 3); // 新增了3秒超时
 
 /// 获取系统语言并决定使用的 locale。
 /// 支持 zh（中文）和 en（英文），其他语言默认使用英文。
@@ -43,12 +45,21 @@ class LocaleNotifier extends ChangeNotifier {
   S get s => currentS;
 
   /// 启动时调用，从 SharedPreferences 恢复语言偏好。
+  /// 给 LocaleNotifier.init() 里的 SharedPreferences.getInstance() 加了 3 秒超时， 超时或异常时记录日志，并回退到系统语言，而不是一直卡住启动。
   Future<void> init() async {
-    final prefs = await SharedPreferences.getInstance();
-    final saved = prefs.getString(_kAppLocale);
-    if (saved != null &&
-        (saved == kLocaleSystem || saved == kLocaleZh || saved == kLocaleEn)) {
-      _preference = saved;
+    try {
+      final prefs = await SharedPreferences.getInstance().timeout(
+        _kPrefsInitTimeout,
+      );
+      final saved = prefs.getString(_kAppLocale);
+      if (saved != null &&
+          (saved == kLocaleSystem ||
+              saved == kLocaleZh ||
+              saved == kLocaleEn)) {
+        _preference = saved;
+      }
+    } catch (e, stack) {
+      logError('LocaleNotifier', 'init failed, using system locale', e, stack);
     }
     _applyLocale();
     // 静默加载，不触发 rebuild（main.dart 会在 init 完成后才 runApp）

--- a/lib/src/services/app_icon_service.dart
+++ b/lib/src/services/app_icon_service.dart
@@ -96,7 +96,7 @@ class AppIconService extends ChangeNotifier {
     try {
       final prefs = await SharedPreferences.getInstance().timeout(
         _kPrefsInitTimeout,
-      ); // 给启动时恢复自定义图标配置的 SharedPreferences.getInstance() 加了 3 秒超时，失败时跳过图标恢复，应用照常启动。
+      );
       var choice = _readChoice(prefs);
       if (choice == AppIconChoice.custom && !hasCustomIcon) {
         choice = AppIconChoice.defaultIcon;

--- a/lib/src/services/app_icon_service.dart
+++ b/lib/src/services/app_icon_service.dart
@@ -14,6 +14,7 @@ import 'platform_utils.dart';
 import 'tray_service.dart';
 
 const _tag = 'AppIconService';
+const _kPrefsInitTimeout = Duration(seconds: 3);
 
 /// 应用图标选择。
 enum AppIconChoice {
@@ -93,7 +94,9 @@ class AppIconService extends ChangeNotifier {
   Future<void> init() async {
     if (!Platform.isWindows) return;
     try {
-      final prefs = await SharedPreferences.getInstance();
+      final prefs = await SharedPreferences.getInstance().timeout(
+        _kPrefsInitTimeout,
+      ); // 给启动时恢复自定义图标配置的 SharedPreferences.getInstance() 加了 3 秒超时，失败时跳过图标恢复，应用照常启动。
       var choice = _readChoice(prefs);
       if (choice == AppIconChoice.custom && !hasCustomIcon) {
         choice = AppIconChoice.defaultIcon;
@@ -267,7 +270,9 @@ class AppIconService extends ChangeNotifier {
     try {
       final out = <IcoPngEntry>[];
       for (final size in _iconSizes) {
-        out.add(IcoPngEntry(size: size, png: await _renderSquarePng(src, size)));
+        out.add(
+          IcoPngEntry(size: size, png: await _renderSquarePng(src, size)),
+        );
       }
       return out;
     } finally {
@@ -281,9 +286,7 @@ class AppIconService extends ChangeNotifier {
     final recorder = ui.PictureRecorder();
     final canvas = ui.Canvas(recorder);
     final side = size.toDouble();
-    final scale = src.width > src.height
-        ? side / src.width
-        : side / src.height;
+    final scale = src.width > src.height ? side / src.width : side / src.height;
     final w = src.width * scale;
     final h = src.height * scale;
     canvas.drawImageRect(

--- a/lib/src/services/window_state_service.dart
+++ b/lib/src/services/window_state_service.dart
@@ -21,6 +21,7 @@ const _kWindowY = 'window_state_y';
 const _kWindowWidth = 'window_state_width';
 const _kWindowHeight = 'window_state_height';
 const _kWindowMaximized = 'window_state_maximized';
+const _kPrefsInitTimeout = Duration(seconds: 3);
 
 /// 窗口最小尺寸限制
 const _kMinWidth = 900.0;
@@ -127,9 +128,37 @@ class WindowStateService {
   ///
   /// 纯读取操作，不调用任何 windowManager API。
   /// 应在 `windowManager.ensureInitialized()` 之后调用。
+  /// 新增3秒超时
   Future<void> loadState() async {
     try {
-      final prefs = await SharedPreferences.getInstance();
+      final prefs = await SharedPreferences.getInstance().timeout(
+        _kPrefsInitTimeout,
+      );
+// 针对您的 132 行到 136 行这段代码，以下是AI给出的结论：
+// 1. WindowStateService.loadState() 是在应用真正进入 UI 之前执行的。
+//      你可以看 /abs/path/C:/Users/TianLang Hacker/Videos/FluxDown/lib/main.dart:143，启动时会先调它，再继续后面的窗口初始
+//      化和 runApp()。
+
+//   2. 如果 SharedPreferences.getInstance() 在某些 Windows 预览版环境里卡住，这里就会把整个启动链堵死。
+//      结果就是：
+//       - 窗口已经建出来了
+//       - Flutter 主界面还没真正跑起来
+//       - 用户看到的就是白屏
+
+//   3. 窗口状态恢复本身不是“必须成功”的操作。
+//      这个服务本来就已经有默认回退逻辑：
+//       - 没有保存尺寸就用默认 1280x720：/abs/path/C:/Users/TianLang Hacker/Videos/FluxDown/lib/src/services/
+//         window_state_service.dart:175
+
+//       - 没有保存位置就居中：/abs/path/C:/Users/TianLang Hacker/Videos/FluxDown/lib/src/services/
+//         window_state_service.dart:203
+
+//      所以这里最合理的策略不是“死等到拿到配置”，而是“3 秒拿不到就放弃恢复，直接用默认窗口启动”。
+
+//   4. 这属于典型的启动期降级设计。
+//      “恢复上次窗口位置失败”是可接受的；
+//      “整个应用永远白屏进不去”是不可接受的。
+
       _savedX = prefs.getDouble(_kWindowX);
       _savedY = prefs.getDouble(_kWindowY);
       _savedWidth = prefs.getDouble(_kWindowWidth);
@@ -404,11 +433,9 @@ class WindowStateService {
         if (getMonitorInfoW(monitor, mi) == 0) return true; // 查询失败不阻塞
         final m = mi.ref.rcMonitor;
         final overlapW =
-            math.min(rect.ref.right, m.right) -
-            math.max(rect.ref.left, m.left);
+            math.min(rect.ref.right, m.right) - math.max(rect.ref.left, m.left);
         final overlapH =
-            math.min(rect.ref.bottom, m.bottom) -
-            math.max(rect.ref.top, m.top);
+            math.min(rect.ref.bottom, m.bottom) - math.max(rect.ref.top, m.top);
         return overlapW >= _kMinVisiblePx && overlapH >= _kMinVisiblePx;
       } finally {
         calloc.free(rect);

--- a/lib/src/services/window_state_service.dart
+++ b/lib/src/services/window_state_service.dart
@@ -128,37 +128,11 @@ class WindowStateService {
   ///
   /// 纯读取操作，不调用任何 windowManager API。
   /// 应在 `windowManager.ensureInitialized()` 之后调用。
-  /// 新增3秒超时
   Future<void> loadState() async {
     try {
       final prefs = await SharedPreferences.getInstance().timeout(
         _kPrefsInitTimeout,
       );
-// 针对您的 132 行到 136 行这段代码，以下是AI给出的结论：
-// 1. WindowStateService.loadState() 是在应用真正进入 UI 之前执行的。
-//      你可以看 /abs/path/C:/Users/TianLang Hacker/Videos/FluxDown/lib/main.dart:143，启动时会先调它，再继续后面的窗口初始
-//      化和 runApp()。
-
-//   2. 如果 SharedPreferences.getInstance() 在某些 Windows 预览版环境里卡住，这里就会把整个启动链堵死。
-//      结果就是：
-//       - 窗口已经建出来了
-//       - Flutter 主界面还没真正跑起来
-//       - 用户看到的就是白屏
-
-//   3. 窗口状态恢复本身不是“必须成功”的操作。
-//      这个服务本来就已经有默认回退逻辑：
-//       - 没有保存尺寸就用默认 1280x720：/abs/path/C:/Users/TianLang Hacker/Videos/FluxDown/lib/src/services/
-//         window_state_service.dart:175
-
-//       - 没有保存位置就居中：/abs/path/C:/Users/TianLang Hacker/Videos/FluxDown/lib/src/services/
-//         window_state_service.dart:203
-
-//      所以这里最合理的策略不是“死等到拿到配置”，而是“3 秒拿不到就放弃恢复，直接用默认窗口启动”。
-
-//   4. 这属于典型的启动期降级设计。
-//      “恢复上次窗口位置失败”是可接受的；
-//      “整个应用永远白屏进不去”是不可接受的。
-
       _savedX = prefs.getDouble(_kWindowX);
       _savedY = prefs.getDouble(_kWindowY);
       _savedWidth = prefs.getDouble(_kWindowWidth);

--- a/lib/src/theme/theme_provider.dart
+++ b/lib/src/theme/theme_provider.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../i18n/locale_provider.dart';
+import '../services/log_service.dart';
 import 'flux_theme_tokens.dart';
 
 // ═══════════════════════════════════════════════════════════
@@ -159,6 +160,7 @@ const _kUiScale = 'ui_scale';
 // 旧版 key（迁移用）
 const _kLegacyCustomThemeDark = 'custom_theme_dark_json';
 const _kLegacyCustomThemeLight = 'custom_theme_light_json';
+const _kPrefsInitTimeout = Duration(seconds: 3);
 
 // ═══════════════════════════════════════════════════════════
 //  ThemeProvider
@@ -288,57 +290,64 @@ class ThemeProvider extends ChangeNotifier {
   //  初始化 & 持久化
   // ═══════════════════════════════════════════════════════════
 
+// 失败时直接使用默认主题配置，不再阻塞进入 UI
   Future<void> init() async {
-    final prefs = await SharedPreferences.getInstance();
-
-    // 主题模式
-    final modeStr = prefs.getString(_kThemeMode);
-    if (modeStr != null) {
-      _themeMode = ThemeMode.values.firstWhere(
-        (m) => m.name == modeStr,
-        orElse: () => ThemeMode.system,
+    try {
+      final prefs = await SharedPreferences.getInstance().timeout(
+        _kPrefsInitTimeout,
       );
-    }
 
-    // 选中的主题
-    final themeStr = prefs.getString(_kSelectedTheme);
-    if (themeStr != null) {
-      _loadSelectedThemes(themeStr);
-    }
-
-    // 强调色方案
-    final schemeStr = prefs.getString(_kColorScheme);
-    if (schemeStr != null) {
-      _colorScheme = AppColorScheme.values.firstWhere(
-        (s) => s.name == schemeStr,
-        orElse: () => AppColorScheme.blue,
-      );
-    }
-
-    // 自定义颜色
-    final customHex = prefs.getString(_kCustomColor);
-    if (customHex != null) {
-      final parsed = int.tryParse(customHex, radix: 16);
-      if (parsed != null) _customColor = Color(parsed);
-    }
-
-    // 导入的主题列表
-    _loadImportedThemes(prefs);
-
-    // 迁移旧版单主题数据
-    _migrateV1(prefs);
-
-    // 选中的自定义主题 ID
-    _selectedCustomDarkId = prefs.getString(_kSelectedCustomDark);
-    _selectedCustomLightId = prefs.getString(_kSelectedCustomLight);
-
-    // 界面缩放
-    final scaleStr = prefs.getString(_kUiScale);
-    if (scaleStr != null) {
-      final parsed = double.tryParse(scaleStr);
-      if (parsed != null && parsed >= 0.8 && parsed <= 1.5) {
-        _uiScale = parsed;
+      // 主题模式
+      final modeStr = prefs.getString(_kThemeMode);
+      if (modeStr != null) {
+        _themeMode = ThemeMode.values.firstWhere(
+          (m) => m.name == modeStr,
+          orElse: () => ThemeMode.system,
+        );
       }
+
+      // 选中的主题
+      final themeStr = prefs.getString(_kSelectedTheme);
+      if (themeStr != null) {
+        _loadSelectedThemes(themeStr);
+      }
+
+      // 强调色方案
+      final schemeStr = prefs.getString(_kColorScheme);
+      if (schemeStr != null) {
+        _colorScheme = AppColorScheme.values.firstWhere(
+          (s) => s.name == schemeStr,
+          orElse: () => AppColorScheme.blue,
+        );
+      }
+
+      // 自定义颜色
+      final customHex = prefs.getString(_kCustomColor);
+      if (customHex != null) {
+        final parsed = int.tryParse(customHex, radix: 16);
+        if (parsed != null) _customColor = Color(parsed);
+      }
+
+      // 导入的主题列表
+      _loadImportedThemes(prefs);
+
+      // 迁移旧版单主题数据
+      _migrateV1(prefs);
+
+      // 选中的自定义主题 ID
+      _selectedCustomDarkId = prefs.getString(_kSelectedCustomDark);
+      _selectedCustomLightId = prefs.getString(_kSelectedCustomLight);
+
+      // 界面缩放
+      final scaleStr = prefs.getString(_kUiScale);
+      if (scaleStr != null) {
+        final parsed = double.tryParse(scaleStr);
+        if (parsed != null && parsed >= 0.8 && parsed <= 1.5) {
+          _uiScale = parsed;
+        }
+      }
+    } catch (e, stack) {
+      logError('ThemeProvider', 'init failed, using defaults', e, stack);
     }
   }
 


### PR DESCRIPTION
新增了3秒超时保护，并且新增了一个逻辑：如果UI拿不到现有主题配置就使用默认主题，防止UI线程卡在这里。