### PR TITLE
fix: open save directory for unfinished tasks

### DIFF
--- a/lib/src/models/download_task.dart
+++ b/lib/src/models/download_task.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'dart:math';
 
 import '../bindings/bindings.dart';
@@ -365,6 +366,32 @@ class DownloadTask {
 
   /// 文件类型分类
   FileCategory get fileCategory => FileCategory.fromExtension(fileExtension);
+
+  /// 任务目标文件的完整路径（`saveDir` + 分隔符 + `fileName`）。
+  ///
+  /// 拼接时去重 `saveDir` 末尾可能存在的路径分隔符，避免产生重复分隔符；
+  /// `saveDir` 为空时退回裸文件名。作为文件路径拼接的单一事实来源，替代散落
+  /// 各处的手写 `'${saveDir}${sep}${fileName}'`。
+  String get filePath {
+    if (saveDir.isEmpty) return fileName;
+    final separator = Platform.pathSeparator;
+    final dir = saveDir.endsWith(separator)
+        ? saveDir.substring(0, saveDir.length - separator.length)
+        : saveDir;
+    return '$dir$separator$fileName';
+  }
+
+  /// 「打开所在文件夹」应传给原生层的路径。
+  ///
+  /// 已完成且文件存在时返回完整文件路径，便于文件管理器定位并选中文件；下载中、
+  /// 暂停、失败、排队、准备中、文件丢失等状态下最终文件可能尚未落盘，改为返回
+  /// 保存目录 [saveDir]，避免原生层将不存在的文件路径误判后打不开任何位置。
+  /// [saveDir] 为空时退回文件路径。
+  String get revealFolderPath {
+    if (status == TaskStatus.completed && !fileMissing) return filePath;
+    if (saveDir.isNotEmpty) return saveDir;
+    return filePath;
+  }
 
   /// 格式化文件大小
   String get sizeText {

--- a/lib/src/services/notification_service.dart
+++ b/lib/src/services/notification_service.dart
@@ -225,7 +225,7 @@ class NotificationService {
     final body = isBatch
         ? '${task.fileName} ${s.andMoreFiles(batch.length - 1)}'
         : task.fileName;
-    final filePath = _resolveFilePath(task);
+    final filePath = task.filePath;
 
     try {
       final details = NotificationDetails(
@@ -352,10 +352,6 @@ class NotificationService {
 
   String _buildPayload({required String action, required String filePath}) {
     return '$action|$filePath';
-  }
-
-  String _resolveFilePath(DownloadTask task) {
-    return '${task.saveDir}${Platform.pathSeparator}${task.fileName}';
   }
 
   void _onSystemNotificationResponse(NotificationResponse response) {

--- a/lib/src/services/win32_toast/win32_toast_window.dart
+++ b/lib/src/services/win32_toast/win32_toast_window.dart
@@ -301,7 +301,7 @@ Future<void> _createToastWindow(_ToastBatch batch) async {
     final y = waBottom - scaledH - margin;
 
     // ── 5. 构建状态 + DIB 资源 ────────────────────────────────────────────
-    final filePath = '${task.saveDir}${Platform.pathSeparator}${task.fileName}';
+    final filePath = task.filePath;
     final state = _ToastState(
       filePath: filePath,
       onOpenFile: () => openFile(filePath),

--- a/lib/src/widgets/task_list.dart
+++ b/lib/src/widgets/task_list.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 import '../i18n/locale_provider.dart';
@@ -73,8 +71,7 @@ class _TaskListState extends State<TaskList> {
         widget.controller.resumeTask(task.id);
       case TaskStatus.completed:
         if (task.fileMissing) return;
-        final filePath =
-            '${task.saveDir}${Platform.pathSeparator}${task.fileName}';
+        final filePath = task.filePath;
         openFile(filePath);
     }
   }

--- a/lib/src/widgets/task_list_item.dart
+++ b/lib/src/widgets/task_list_item.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
@@ -464,8 +462,8 @@ void showTaskContextMenu(
   }
 
   // --- 打开文件 / 打开所在文件夹 ---
-  final filePath = _taskFilePath(task);
-  final folderPath = _taskFolderRevealPath(task, filePath);
+  final filePath = task.filePath;
+  final folderPath = task.revealFolderPath;
 
   if (task.status == TaskStatus.completed && !task.fileMissing) {
     items.add(
@@ -549,27 +547,6 @@ void showTaskContextMenu(
 Future<void> _openFile(String filePath) => openFile(filePath);
 
 Future<void> _openFolder(String filePath) => openFolder(filePath);
-
-String _taskFilePath(DownloadTask task) {
-  if (task.saveDir.isEmpty) return task.fileName;
-  final separator = Platform.pathSeparator;
-  final saveDir = task.saveDir.endsWith(separator)
-      ? task.saveDir.substring(0, task.saveDir.length - separator.length)
-      : task.saveDir;
-  return '$saveDir$separator${task.fileName}';
-}
-
-String _taskFolderRevealPath(DownloadTask task, String filePath) {
-  if (task.status == TaskStatus.completed && !task.fileMissing) {
-    return filePath;
-  }
-
-  if (task.saveDir.isNotEmpty) {
-    return task.saveDir;
-  }
-
-  return filePath;
-}
 
 // =============================================================================
 // 单任务删除确认对话框（原有，保留兼容性）

--- a/lib/src/widgets/task_list_item.dart
+++ b/lib/src/widgets/task_list_item.dart
@@ -464,7 +464,8 @@ void showTaskContextMenu(
   }
 
   // --- 打开文件 / 打开所在文件夹 ---
-  final filePath = '${task.saveDir}${Platform.pathSeparator}${task.fileName}';
+  final filePath = _taskFilePath(task);
+  final folderPath = _taskFolderRevealPath(task, filePath);
 
   if (task.status == TaskStatus.completed && !task.fileMissing) {
     items.add(
@@ -481,7 +482,7 @@ void showTaskContextMenu(
       icon: LucideIcons.folderOpen,
       label: s.openFolder,
       color: c.textPrimary,
-      action: () => _openFolder(filePath),
+      action: () => _openFolder(folderPath),
     ),
   );
   dividers.add(items.length - 1); // 文件操作组后加分隔线
@@ -548,6 +549,27 @@ void showTaskContextMenu(
 Future<void> _openFile(String filePath) => openFile(filePath);
 
 Future<void> _openFolder(String filePath) => openFolder(filePath);
+
+String _taskFilePath(DownloadTask task) {
+  if (task.saveDir.isEmpty) return task.fileName;
+  final separator = Platform.pathSeparator;
+  final saveDir = task.saveDir.endsWith(separator)
+      ? task.saveDir.substring(0, task.saveDir.length - separator.length)
+      : task.saveDir;
+  return '$saveDir$separator${task.fileName}';
+}
+
+String _taskFolderRevealPath(DownloadTask task, String filePath) {
+  if (task.status == TaskStatus.completed && !task.fileMissing) {
+    return filePath;
+  }
+
+  if (task.saveDir.isNotEmpty) {
+    return task.saveDir;
+  }
+
+  return filePath;
+}
 
 // =============================================================================
 // 单任务删除确认对话框（原有，保留兼容性）


### PR DESCRIPTION
## 概述

修复未完成下载任务的「打开所在文件夹」行为。

此前右键菜单始终把最终文件路径（`saveDir/fileName`）传给打开目录逻辑。对于下载中、暂停、失败或文件丢失的任务，最终文件可能还不存在，原生层可能会把这个路径误判为不存在的目录，导致点击后没有打开任何位置。

本次改动保留已完成任务的行为不变：文件存在时仍然定位到具体文件；未完成或异常状态的任务则直接打开保存目录。

## 改动内容

- 已完成且文件存在的任务继续使用完整文件路径，方便在文件管理器中定位文件。
- 下载中、暂停、失败、排队、准备中、文件丢失等状态改为直接打开 `task.saveDir`。
- 统一封装任务文件路径拼接，避免保存目录末尾带分隔符时产生重复分隔符。