### PR TITLE
feat: 支持使用服务器提供的文件时间

### DIFF
--- a/lib/src/i18n/translations.dart
+++ b/lib/src/i18n/translations.dart
@@ -469,6 +469,11 @@ class S {
     '浏览器扩展等外部下载请求不再弹出确认框，直接按默认设置开始下载',
     'Start external downloads (e.g. from the browser extension) immediately with default settings, without showing the confirmation dialog',
   );
+  String get useServerTime => _t('使用服务器文件时间', 'Use Server File Time');
+  String get useServerTimeDesc => _t(
+    '下载完成后将文件的修改时间设为服务器提供的原始时间（Last-Modified），而非下载完成时间',
+    'Set the modified time of completed files to the server-provided original time (Last-Modified) instead of the download completion time',
+  );
   String get keepAwakeWhileDownloading =>
       _t('下载时保持唤醒', 'Keep Awake While Downloading');
   String get keepAwakeWhileDownloadingDesc => _t(
@@ -1223,6 +1228,10 @@ class S {
     '免打扰,静默,确认框,弹窗,扩展,自动下载',
     'silent,quiet,confirm,dialog,extension,auto',
   ).split(',')..addAll(['silent', 'confirm', 'dialog']);
+  List<String> get searchKeywordsUseServerTime => _t(
+    '文件时间,修改时间,时间戳,服务器时间',
+    'file time,modified time,timestamp,server time',
+  ).split(',')..addAll(['time', 'timestamp', 'mtime', 'last-modified']);
   List<String> get searchKeywordsKeepAwake => _t(
     '唤醒,睡眠,息屏,锁屏,休眠,屏幕',
     'awake,sleep,screen,lock,display,wake,caffeinate',

--- a/lib/src/models/settings_provider.dart
+++ b/lib/src/models/settings_provider.dart
@@ -30,6 +30,7 @@ class SettingsProvider extends ChangeNotifier {
   bool _autoCheckUpdate = true; // 默认启动时自动检查更新
   bool _notifyOnComplete = true; // 默认任务完成时弹出通知
   bool _silentDownloadEnabled = false; // 免打扰下载：外部请求不弹确认框直接下载
+  bool _useServerTime = false; // 完成文件的修改时间采用服务器 Last-Modified
   bool _keepAwakeWhileDownloading = false; // 默认不阻止睡眠/息屏
   int _logMaxSizeMb = 10; // 日志总大小上限（MB），超出自动清理
 
@@ -191,6 +192,7 @@ class SettingsProvider extends ChangeNotifier {
   bool get autoCheckUpdate => _autoCheckUpdate;
   bool get notifyOnComplete => _notifyOnComplete;
   bool get silentDownloadEnabled => _silentDownloadEnabled;
+  bool get useServerTime => _useServerTime;
   bool get keepAwakeWhileDownloading => _keepAwakeWhileDownloading;
   int get logMaxSizeMb => _logMaxSizeMb;
 
@@ -519,6 +521,13 @@ class SettingsProvider extends ChangeNotifier {
     _silentDownloadEnabled = value;
     notifyListeners();
     _saveToRust('silent_download_enabled', value.toString());
+  }
+
+  void setUseServerTime(bool value) {
+    if (_useServerTime == value) return;
+    _useServerTime = value;
+    notifyListeners();
+    _saveToRust('use_server_time', value.toString());
   }
 
   void setKeepAwakeWhileDownloading(bool value) {
@@ -1202,6 +1211,8 @@ class SettingsProvider extends ChangeNotifier {
           _notifyOnComplete = entry.value != 'false'; // 默认 true
         case 'silent_download_enabled':
           _silentDownloadEnabled = entry.value == 'true'; // 默认 false
+        case 'use_server_time':
+          _useServerTime = entry.value == 'true'; // 默认 false
         case 'keep_awake_while_downloading':
           _keepAwakeWhileDownloading = entry.value == 'true'; // 默认 false
         case 'floating_ball_enabled':

--- a/lib/src/pages/settings_page.dart
+++ b/lib/src/pages/settings_page.dart
@@ -245,6 +245,13 @@ List<SettingsSearchItem> get settingsSearchItems {
     ),
     SettingsSearchItem(
       category: SettingsCategory.download,
+      label: s.useServerTime,
+      description: s.useServerTimeDesc,
+      keywords: s.searchKeywordsUseServerTime,
+      icon: LucideIcons.clock,
+    ),
+    SettingsSearchItem(
+      category: SettingsCategory.download,
       label: s.defaultThreads,
       description: s.defaultThreadsDesc,
       keywords: s.searchKeywordsThreads,
@@ -2382,6 +2389,15 @@ class _DownloadContent extends StatelessWidget {
               child: ShadSwitch(
                 value: settingsProvider.silentDownloadEnabled,
                 onChanged: (v) => settingsProvider.setSilentDownloadEnabled(v),
+              ),
+            ),
+            const SizedBox(height: 10),
+            _SettingCard(
+              label: s.useServerTime,
+              description: s.useServerTimeDesc,
+              child: ShadSwitch(
+                value: settingsProvider.useServerTime,
+                onChanged: (v) => settingsProvider.setUseServerTime(v),
               ),
             ),
             const SizedBox(height: 10),

--- a/native/api/src/aria2.rs
+++ b/native/api/src/aria2.rs
@@ -470,6 +470,16 @@ fn to_native_int(s: &str) -> Result<String, String> {
         .map_err(|_| format!("invalid integer: {s}"))
 }
 
+/// aria2 `Boolean` 格式的选项值：仅接受 `true`/`false`，其余视为非法值
+/// 整体拒绝（同 [`to_native_int`] 的净化理由：非法值绝不写进 config 表）。
+fn to_native_bool(s: &str) -> Result<String, String> {
+    match s.trim() {
+        "true" => Ok("true".to_string()),
+        "false" => Ok("false".to_string()),
+        _ => Err(format!("invalid boolean: {s}")),
+    }
+}
+
 /// 契约表：`local://aria2_compat_contract.md` §「aria2 全局选项 ↔ FluxDown
 /// config key 映射」。
 const GLOBAL_OPTION_MAPPINGS: &[GlobalOptionMapping] = &[
@@ -502,6 +512,12 @@ const GLOBAL_OPTION_MAPPINGS: &[GlobalOptionMapping] = &[
         config_key: "global_user_agent",
         to_native: identity,
         default_native: "aria2/1.37.0",
+    },
+    GlobalOptionMapping {
+        aria2_key: "remote-time",
+        config_key: "use_server_time",
+        to_native: to_native_bool,
+        default_native: "false",
     },
 ];
 
@@ -538,7 +554,7 @@ pub(crate) fn map_change_global_options(
     Ok(changes)
 }
 
-/// `getGlobalOption`：映射表 5 键的真实值（缺省时用 aria2 出厂默认兜底）
+/// `getGlobalOption`：映射表各键的真实值（缺省时用 aria2 出厂默认兜底）
 /// + 一组静态合理默认，全部字符串值。
 pub(crate) fn build_global_option(config: &HashMap<String, String>) -> Value {
     let mut obj = Map::new();
@@ -1075,6 +1091,7 @@ mod tests {
             "max-overall-download-limit": "10M",
             "split": "16",
             "user-agent": "UA/9",
+            "remote-time": "true",
             "totally-unknown-option": "ignored",
         });
         let changes = map_change_global_options(options.as_object().unwrap()).unwrap();
@@ -1086,7 +1103,8 @@ mod tests {
         );
         assert_eq!(changes.get("default_segments").unwrap(), "16");
         assert_eq!(changes.get("global_user_agent").unwrap(), "UA/9");
-        assert_eq!(changes.len(), 5);
+        assert_eq!(changes.get("use_server_time").unwrap(), "true");
+        assert_eq!(changes.len(), 6);
     }
 
     #[test]
@@ -1111,6 +1129,12 @@ mod tests {
     #[test]
     fn map_change_global_options_errors_on_invalid_split() {
         let options = json!({ "split": "lots" });
+        assert!(map_change_global_options(options.as_object().unwrap()).is_err());
+    }
+
+    #[test]
+    fn map_change_global_options_errors_on_invalid_remote_time() {
+        let options = json!({ "remote-time": "yes" });
         assert!(map_change_global_options(options.as_object().unwrap()).is_err());
     }
 

--- a/native/engine/src/download_manager.rs
+++ b/native/engine/src/download_manager.rs
@@ -592,6 +592,9 @@ pub struct DownloadManager {
     /// Auto 模式最大连接数上限（config `auto_max_connections`）。
     /// <=0 = 不限（罕见，仅显式配置），默认 [`DEFAULT_AUTO_MAX_CONNECTIONS`]。
     auto_max_connections: i32,
+    /// 下载完成后是否把文件修改时间设为服务器提供的 `Last-Modified` 时间
+    /// （config `use_server_time`，默认关闭）。
+    use_server_time: bool,
     /// In-memory cache of named queue settings (queue_id → QueueInfo).
     /// Kept in sync with the DB on every queue CRUD operation.
     queues: HashMap<String, QueueInfo>,
@@ -699,6 +702,7 @@ impl DownloadManager {
             global_user_agent: user_agent,
             global_default_segments: 0,
             auto_max_connections: DEFAULT_AUTO_MAX_CONNECTIONS,
+            use_server_time: false,
             queues: HashMap::new(),
             queue_limiters: HashMap::new(),
             startup_reset_done: false,
@@ -790,6 +794,15 @@ impl DownloadManager {
     /// <=0 = unlimited (advisor value used as-is).
     pub fn set_auto_max_connections(&mut self, v: i32) {
         self.auto_max_connections = v;
+    }
+
+    /// Update whether completed downloads adopt the server-provided
+    /// `Last-Modified` timestamp as the file's modification time
+    /// (config `use_server_time`). Takes effect for downloads started
+    /// after the change; already-running downloads keep the value they
+    /// were spawned with.
+    pub fn set_use_server_time(&mut self, v: bool) {
+        self.use_server_time = v;
     }
 
     /// Update global speed limit (bytes/sec).  Takes effect immediately on
@@ -2227,6 +2240,7 @@ impl DownloadManager {
                 spec,
                 audio_url,
                 auto_max_connections: self.auto_max_connections,
+                use_server_time: self.use_server_time,
             };
 
             tokio::spawn(async move {
@@ -2839,6 +2853,7 @@ impl DownloadManager {
                 ),
                 audio_url,
                 auto_max_connections: self.auto_max_connections,
+                use_server_time: self.use_server_time,
             };
 
             tokio::spawn(async move {

--- a/native/engine/src/downloader.rs
+++ b/native/engine/src/downloader.rs
@@ -3100,7 +3100,16 @@ async fn run_download_inner(p: &DownloadParams) -> Result<(i64, Option<String>),
     );
 
     if p.use_server_time {
-        apply_server_mtime(&final_dest, &resume_last_modified, &p.task_id).await;
+        // 单流路径优先用【实际响应】锁存的 Last-Modified：If-Range 失配（文件在
+        // 暂停/下载期间变更）会导致 200 全量重下新内容，此时 probe/DB validator
+        // 里的旧时间已不属于磁盘上的字节。多段路径无此偏差——validator 失配即
+        // 整体作废并回退单流（同样拿到锁存值），仍走多段完成的只能是原版本文件，
+        // probe/DB 值即正确值。
+        let last_modified = single_result
+            .as_ref()
+            .and_then(|r| r.latched_last_modified.as_deref())
+            .unwrap_or(&resume_last_modified);
+        apply_server_mtime(&final_dest, last_modified, &p.task_id).await;
     }
 
     Ok((actual_total, finalize_renamed))
@@ -3208,6 +3217,12 @@ struct SingleDownloadResult {
     /// *decompressed* size, which has no relation to the probe's (compressed)
     /// `total_bytes` — the caller MUST skip the file-size integrity check.
     decompressed: bool,
+    /// 服务器【实际响应】的 `Last-Modified`。仅当响应体从 byte 0 全量服务时为
+    /// `Some`（全新下载，或 If-Range 失配回退 200 重下新版本）——此时磁盘内容
+    /// 以该响应为准，probe/DB validator 可能描述的是旧版本，调用方设置文件
+    /// mtime 时必须优先采用本值（空串 = 该响应未携带此头，应放弃服务器时间）。
+    /// 真 206 续传为 `None`（磁盘内容与旧 validator 一致，沿用旧值）。
+    latched_last_modified: Option<String>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -3402,6 +3417,14 @@ async fn download_single(
             existing_len
         );
     }
+    // 从 0 服务的全量体：锁存实际响应的 Last-Modified（见字段 doc）。
+    let latched_last_modified = (!actual_resume).then(|| {
+        resp.headers()
+            .get(reqwest::header::LAST_MODIFIED)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string()
+    });
 
     // Capture the response's own Content-Length before consuming the body.
     // For resumed downloads (206), this is the *remaining* length, not total.
@@ -3530,6 +3553,7 @@ async fn download_single(
     Ok(SingleDownloadResult {
         response_content_length,
         decompressed: encoding.is_some(),
+        latched_last_modified,
     })
 }
 

--- a/native/engine/src/downloader.rs
+++ b/native/engine/src/downloader.rs
@@ -237,6 +237,10 @@ pub struct DownloadParams {
     /// 的推荐值：`effective = min(advisor, auto_max_connections)`。<=0 视为不限
     /// （回退 advisor 原值）。用户显式指定 segment_count 时本字段不参与。
     pub auto_max_connections: i32,
+    /// 下载完成后是否把文件修改时间设为服务器提供的 `Last-Modified` 时间
+    /// （config `use_server_time`）。服务器未提供该头、解析失败或写入失败时
+    /// 保留本地完成时间，绝不影响下载结果。
+    pub use_server_time: bool,
 }
 
 /// 将浏览器扩展捕获的额外 HTTP 头应用到请求构建器上。
@@ -3095,7 +3099,98 @@ async fn run_download_inner(p: &DownloadParams) -> Result<(i64, Option<String>),
         final_dest.display()
     );
 
+    if p.use_server_time {
+        apply_server_mtime(&final_dest, &resume_last_modified, &p.task_id).await;
+    }
+
     Ok((actual_total, finalize_renamed))
+}
+
+/// 将 HTTP 日期字符串解析为 [`std::time::SystemTime`]。
+///
+/// 覆盖 RFC 9110 §5.6.7 允许的三种格式：IMF-fixdate
+/// （`Sun, 06 Nov 1994 08:49:37 GMT`，RFC 2822 子集）、过时的 RFC 850
+/// （`Sunday, 06-Nov-94 08:49:37 GMT`）与 ANSI C `asctime()`
+/// （`Sun Nov  6 08:49:37 1994`，按 UTC 解释）。
+///
+/// 星期字段是冗余修饰，现实中偶见服务器生成与日期不符的星期——若做一致性
+/// 校验会整体拒绝本可用的时间戳，故解析前一律剥离星期、只信日期本身。
+/// 全部格式失败、或时间早于 Unix 纪元（无法表示为文件时间戳）时返回 `None`。
+fn parse_http_date(s: &str) -> Option<std::time::SystemTime> {
+    let s = s.trim();
+    let ts = if let Some((_, rest)) = s.split_once(',') {
+        // IMF-fixdate 与 RFC 850 都以「星期,」开头；剥离后按剩余字段解析
+        // （RFC 2822 的星期本就可选，直接解析剩余部分即合法输入）。
+        let rest = rest.trim();
+        chrono::DateTime::parse_from_rfc2822(rest)
+            .map(|dt| dt.timestamp())
+            .or_else(|_| {
+                chrono::NaiveDateTime::parse_from_str(rest, "%d-%b-%y %H:%M:%S GMT")
+                    .map(|dt| dt.and_utc().timestamp())
+            })
+            .ok()?
+    } else {
+        // 无逗号：标准 RFC 2822（省略星期）或 asctime（首个空格前为星期缩写）。
+        chrono::DateTime::parse_from_rfc2822(s)
+            .map(|dt| dt.timestamp())
+            .or_else(|_| {
+                let rest = s.split_once(' ').map_or(s, |(_, r)| r).trim();
+                chrono::NaiveDateTime::parse_from_str(rest, "%b %e %H:%M:%S %Y")
+                    .map(|dt| dt.and_utc().timestamp())
+            })
+            .ok()?
+    };
+    let secs = u64::try_from(ts).ok()?;
+    Some(std::time::UNIX_EPOCH + Duration::from_secs(secs))
+}
+
+/// 把已完成下载的最终文件修改时间设为服务器提供的 `Last-Modified` 时间。
+///
+/// 时间戳属于尽力而为的元数据：`last_modified` 为空（服务器未提供）、解析
+/// 失败或写入失败都只记日志直接返回——此刻文件数据已完整落盘，任何元数据
+/// 失败都不允许把成功的下载变成错误。
+async fn apply_server_mtime(dest: &Path, last_modified: &str, task_id: &str) {
+    if last_modified.is_empty() {
+        return;
+    }
+    let Some(mtime) = parse_http_date(last_modified) else {
+        log_info!(
+            "[download] task {} 无法解析 Last-Modified \"{}\"，保留本地完成时间",
+            task_id,
+            last_modified
+        );
+        return;
+    };
+    let path = dest.to_path_buf();
+    // set_times 是同步系统调用，且 Windows 上需要以写权限打开句柄。
+    let result = tokio::task::spawn_blocking(move || {
+        let file = std::fs::OpenOptions::new().write(true).open(&path)?;
+        file.set_times(std::fs::FileTimes::new().set_modified(mtime))
+    })
+    .await;
+    match result {
+        Ok(Ok(())) => {
+            log_info!(
+                "[download] task {} 文件修改时间已设为服务器时间 {}",
+                task_id,
+                last_modified
+            );
+        }
+        Ok(Err(e)) => {
+            log_info!(
+                "[download] task {} 设置服务器文件时间失败：{}（保留本地完成时间）",
+                task_id,
+                e
+            );
+        }
+        Err(e) => {
+            log_info!(
+                "[download] task {} 设置服务器文件时间的阻塞任务异常：{}",
+                task_id,
+                e
+            );
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -3511,9 +3606,46 @@ mod tests {
     use super::{
         PROBE_MAX_RETRIES, PROBE_RETRY_BASE_DELAY, PROBE_TIMEOUT, TEMP_EXT, dedup_filename,
         extract_filename, extract_from_content_disposition, extract_from_url, format_probe_failure,
-        mime_to_ext, sanitize_filename, urlencoding_decode,
+        mime_to_ext, parse_http_date, sanitize_filename, urlencoding_decode,
     };
     use std::time::Duration;
+
+    // -----------------------------------------------------------------------
+    // parse_http_date
+    // -----------------------------------------------------------------------
+
+    /// 三种 HTTP 日期格式指向同一时刻（784111777 = 1994-11-06T08:49:37Z）。
+    #[test]
+    fn parse_http_date_accepts_all_three_http_formats() {
+        let expected = std::time::UNIX_EPOCH + Duration::from_secs(784_111_777);
+        for s in [
+            "Sun, 06 Nov 1994 08:49:37 GMT",
+            "Sunday, 06-Nov-94 08:49:37 GMT",
+            "Sun Nov  6 08:49:37 1994",
+        ] {
+            assert_eq!(parse_http_date(s), Some(expected), "format: {s}");
+        }
+    }
+
+    /// 星期与日期不符的头（现实中偶见）不应导致整个时间戳被拒绝。
+    /// 2025-10-21 实为周二，此处故意标注 Wed。
+    #[test]
+    fn parse_http_date_ignores_mismatched_weekday() {
+        let expected = std::time::UNIX_EPOCH + Duration::from_secs(1_761_031_680);
+        assert_eq!(
+            parse_http_date("Wed, 21 Oct 2025 07:28:00 GMT"),
+            Some(expected)
+        );
+    }
+
+    #[test]
+    fn parse_http_date_rejects_garbage_and_pre_epoch() {
+        assert_eq!(parse_http_date(""), None);
+        assert_eq!(parse_http_date("not a date"), None);
+        assert_eq!(parse_http_date("2025-01-01T00:00:00Z"), None);
+        // Unix 纪元之前的时间无法表示为 SystemTime 偏移，须整体放弃。
+        assert_eq!(parse_http_date("Wed, 01 Jan 1902 00:00:00 GMT"), None);
+    }
 
     // -----------------------------------------------------------------------
     // sanitize_filename

--- a/native/engine/tests/realtest.rs
+++ b/native/engine/tests/realtest.rs
@@ -1273,6 +1273,7 @@ async fn run_full(
         extra_headers: std::collections::HashMap::new(),
         spec: RequestSpec::empty_get(),
         audio_url: None,
+        use_server_time: false,
     };
 
     run_download(params).await;
@@ -1303,6 +1304,119 @@ async fn insert_simple_task(
     )
     .await
     .expect("insert_task");
+}
+
+/// 同 run_full 的精简版，额外暴露 `use_server_time` 开关（服务器 Last-Modified
+/// 作为文件修改时间）。固定 4 分段驱动 coordinator 多段路径 + 共享 finalize。
+async fn run_full_server_time(
+    work_dir: &Path,
+    db: &Db,
+    task_id: &str,
+    url: &str,
+    file_name: &str,
+    use_server_time: bool,
+) -> (i32, std::path::PathBuf) {
+    use fluxdown_engine::downloader::{DownloadParams, run_download};
+
+    let client = test_client();
+    let speed_limiter = SpeedLimiter::new(0);
+    let (tx, mut rx) = mpsc::channel::<ProgressUpdate>(256);
+    let last_status = Arc::new(std::sync::atomic::AtomicI32::new(0));
+    let ls = last_status.clone();
+    let collector = tokio::spawn(async move {
+        while let Some(u) = rx.recv().await {
+            if u.status >= 3 {
+                ls.store(u.status, std::sync::atomic::Ordering::SeqCst);
+            }
+        }
+    });
+
+    let params = DownloadParams {
+        auto_max_connections: 0,
+        task_id: task_id.to_string(),
+        url: url.to_string(),
+        save_dir: work_dir.to_string_lossy().to_string(),
+        file_name: file_name.to_string(),
+        segment_count: 4,
+        is_resume: false,
+        range_verified: true,
+        db: db.clone(),
+        client,
+        progress_tx: tx,
+        cancel_token: CancellationToken::new(),
+        speed_limiter,
+        cookies: String::new(),
+        referrer: String::new(),
+        hint_file_size: 0,
+        proxy_config: ProxyConfig::default(),
+        sink: std::sync::Arc::new(NoopTestSink),
+        selector: std::sync::Arc::new(fluxdown_engine::NoopSelection),
+        checksum: String::new(),
+        extra_headers: std::collections::HashMap::new(),
+        spec: RequestSpec::empty_get(),
+        audio_url: None,
+        use_server_time,
+    };
+
+    run_download(params).await;
+    let _ = collector.await;
+    let status = last_status.load(std::sync::atomic::Ordering::SeqCst);
+    (status, work_dir.join(file_name))
+}
+
+// ---------------------------------------------------------------------------
+// use_server_time：完成文件的 mtime 应采用服务器 Last-Modified；关闭时不采用
+// ---------------------------------------------------------------------------
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "binds a local port; run with --ignored"]
+async fn use_server_time_applies_last_modified_to_file_mtime() {
+    let work_dir = unique_dir("servertime");
+    let _ = tokio::fs::remove_dir_all(&work_dir).await;
+    tokio::fs::create_dir_all(&work_dir).await.unwrap();
+
+    let body = gen_body(300_000, 777);
+    let st = Arc::new(ServerState::new(Arc::new(body), "etm"));
+    let server = start_server(st).await;
+
+    // 服务器 Last-Modified = "Wed, 21 Oct 2025 07:28:00 GMT"（ServerState 默认值）
+    // → 2025-10-21T07:28:00Z = 1761031680。该头的星期字段与日期不符（实为周二），
+    // 顺带守护 parse_http_date 的「剥离星期」宽松语义在端到端路径上生效。
+    let expected = std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_761_031_680);
+
+    let db = Db::open(&work_dir).await.expect("db");
+
+    // 开启：mtime 必须等于服务器时间。
+    let url = server.url("/on.bin");
+    insert_simple_task(&db, &work_dir, "mt-on", &url, "on.bin", 4, 300_000).await;
+    let (status, dest) = run_full_server_time(&work_dir, &db, "mt-on", &url, "on.bin", true).await;
+    assert_eq!(status, 3, "❌ 下载未成功");
+    let mtime = tokio::fs::metadata(&dest)
+        .await
+        .expect("metadata")
+        .modified()
+        .expect("mtime");
+    assert_eq!(
+        mtime, expected,
+        "❌ 开启 use_server_time 后文件 mtime 应等于服务器 Last-Modified"
+    );
+
+    // 关闭：mtime 保持本地完成时间（晚于服务器时间，且不相等）。
+    let url = server.url("/off.bin");
+    insert_simple_task(&db, &work_dir, "mt-off", &url, "off.bin", 4, 300_000).await;
+    let (status, dest) =
+        run_full_server_time(&work_dir, &db, "mt-off", &url, "off.bin", false).await;
+    assert_eq!(status, 3, "❌ 下载未成功");
+    let mtime = tokio::fs::metadata(&dest)
+        .await
+        .expect("metadata")
+        .modified()
+        .expect("mtime");
+    assert!(
+        mtime > expected,
+        "❌ 关闭 use_server_time 时文件 mtime 应为本地完成时间，而非服务器时间"
+    );
+
+    drop(server);
 }
 
 // ---------------------------------------------------------------------------
@@ -2261,6 +2375,7 @@ async fn resume_of_unverified_hint_task_stays_plain_get() {
         extra_headers: std::collections::HashMap::new(),
         spec: RequestSpec::empty_get(),
         audio_url: None,
+        use_server_time: false,
     };
     run_download(params).await;
     let _ = collector.await;
@@ -2490,6 +2605,7 @@ async fn manual_real_url_hint_download() {
         extra_headers: std::collections::HashMap::new(),
         spec: RequestSpec::empty_get(),
         audio_url: None,
+        use_server_time: false,
     };
     run_download(params).await;
     let _ = collector.await;

--- a/native/engine/tests/realtest.rs
+++ b/native/engine/tests/realtest.rs
@@ -47,7 +47,8 @@ struct ServerState {
     body: Mutex<Arc<Vec<u8>>>,
     /// 当前 ETag（随 body 一起切换）。
     etag: Mutex<String>,
-    last_modified: String,
+    /// 当前 Last-Modified（可随 swap 钩子一起切换，模拟文件变更后的新时间）。
+    last_modified: Mutex<String>,
     content_type: String,
 
     /// false → 忽略所有 Range 请求，永远返回 200 全量，且不发 Accept-Ranges。
@@ -60,6 +61,9 @@ struct ServerState {
     // --- 故障注入钩子 ---
     /// 在累计第 N 个 *range* GET 完成后，把 body/etag 切换为 (新 body, 新 etag)。
     swap_after_range_gets: Option<(usize, Arc<Vec<u8>>, String)>,
+    /// swap 钩子附加项：切换 body/etag 的同时把 Last-Modified 换成该值
+    /// （None = 保持不变，既有测试零影响）。
+    swap_last_modified: Option<String>,
     /// 对第 N 个 *range* GET（1-indexed），只写响应体前 K 字节然后强行关闭连接
     /// （模拟传输中途断流 → 触发引擎重试/续传）。仅生效一次。
     drop_range_get_nth: Option<(usize, usize)>,
@@ -119,12 +123,13 @@ impl ServerState {
         Self {
             body: Mutex::new(body),
             etag: Mutex::new(etag.to_string()),
-            last_modified: "Wed, 21 Oct 2025 07:28:00 GMT".to_string(),
+            last_modified: Mutex::new("Wed, 21 Oct 2025 07:28:00 GMT".to_string()),
             content_type: "application/octet-stream".to_string(),
             support_range: true,
             advertise_accept_ranges: true,
             fake_full_content_length: None,
             swap_after_range_gets: None,
+            swap_last_modified: None,
             drop_range_get_nth: None,
             corrupt_range_get_nth: None,
             gzip_body: None,
@@ -291,6 +296,7 @@ async fn handle_conn(mut stream: TcpStream, st: Arc<ServerState>) -> std::io::Re
 
     let body = st.body.lock().await.clone();
     let etag = st.etag.lock().await.clone();
+    let last_modified = st.last_modified.lock().await.clone();
     let total = body.len() as i64;
 
     if std::env::var("RT_TRACE").is_ok() {
@@ -331,7 +337,7 @@ async fn handle_conn(mut stream: TcpStream, st: Arc<ServerState>) -> std::io::Re
             h.push_str("Accept-Ranges: bytes\r\n");
         }
         h.push_str(&format!("ETag: \"{}\"\r\n", etag));
-        h.push_str(&format!("Last-Modified: {}\r\n", st.last_modified));
+        h.push_str(&format!("Last-Modified: {}\r\n", last_modified));
         h.push_str(&format!("Content-Type: {}\r\n", st.content_type));
         h.push_str("Connection: close\r\n\r\n");
         write_all(&mut stream, h.as_bytes()).await?;
@@ -345,7 +351,7 @@ async fn handle_conn(mut stream: TcpStream, st: Arc<ServerState>) -> std::io::Re
     // 全量当前文件**。FluxDown 的续传/分段修复正是依赖这一点来检出"文件中途变化"。
     let if_range_matches = match &req.if_range {
         None => true, // 无 If-Range → 正常按 Range 处理
-        Some(v) => v == &format!("\"{}\"", etag) || v == &st.last_modified,
+        Some(v) => v == &format!("\"{}\"", etag) || v == &last_modified,
     };
     let wants_range = req.range.is_some() && st.support_range && if_range_matches;
 
@@ -399,7 +405,7 @@ async fn handle_conn(mut stream: TcpStream, st: Arc<ServerState>) -> std::io::Re
             h.push_str("Accept-Ranges: bytes\r\n");
         }
         h.push_str(&format!("ETag: \"{}\"\r\n", etag));
-        h.push_str(&format!("Last-Modified: {}\r\n", st.last_modified));
+        h.push_str(&format!("Last-Modified: {}\r\n", last_modified));
         h.push_str(&format!("Content-Type: {}\r\n", st.content_type));
         h.push_str("Connection: close\r\n\r\n");
         write_all(&mut stream, h.as_bytes()).await?;
@@ -467,7 +473,7 @@ async fn handle_conn(mut stream: TcpStream, st: Arc<ServerState>) -> std::io::Re
     h.push_str("Accept-Ranges: bytes\r\n");
     if st.emit_validators_on_range {
         h.push_str(&format!("ETag: \"{}\"\r\n", etag));
-        h.push_str(&format!("Last-Modified: {}\r\n", st.last_modified));
+        h.push_str(&format!("Last-Modified: {}\r\n", last_modified));
     }
     h.push_str(&format!("Content-Type: {}\r\n", st.content_type));
     h.push_str("Connection: close\r\n\r\n");
@@ -500,13 +506,16 @@ async fn handle_conn(mut stream: TcpStream, st: Arc<ServerState>) -> std::io::Re
     }
     let _ = stream.shutdown().await;
 
-    // body 切换注入：达到阈值后替换 body+etag（模拟下载中文件变化）
+    // body 切换注入：达到阈值后替换 body+etag（+可选 Last-Modified），模拟下载中文件变化
     if let Some((after, ref new_body, ref new_etag)) = st.swap_after_range_gets
         && n >= after
         && st.swapped.swap(1, Ordering::SeqCst) == 0
     {
         *st.body.lock().await = new_body.clone();
         *st.etag.lock().await = new_etag.clone();
+        if let Some(new_lm) = &st.swap_last_modified {
+            *st.last_modified.lock().await = new_lm.clone();
+        }
     }
 
     Ok(())
@@ -1414,6 +1423,106 @@ async fn use_server_time_applies_last_modified_to_file_mtime() {
     assert!(
         mtime > expected,
         "❌ 关闭 use_server_time 时文件 mtime 应为本地完成时间，而非服务器时间"
+    );
+
+    drop(server);
+}
+
+// ---------------------------------------------------------------------------
+// use_server_time：暂停期间文件变更（续传 If-Range 失配 → 200 全量重下新版本）
+// 时，mtime 必须采用【新版本】的 Last-Modified，而非 DB 旧 validator 的时间
+// ---------------------------------------------------------------------------
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "binds a local port; run with --ignored"]
+async fn use_server_time_uses_new_last_modified_after_version_change() {
+    use fluxdown_engine::downloader::{DownloadParams, TEMP_EXT, run_download};
+
+    let work_dir = unique_dir("servertime_swap");
+    let _ = tokio::fs::remove_dir_all(&work_dir).await;
+    tokio::fs::create_dir_all(&work_dir).await.unwrap();
+
+    let size = 300_000usize;
+    let body_v1 = gen_body(size, 111);
+    let body_v2 = gen_body(size, 222);
+
+    // 服务器上已是【新版本】：etag-v2 + 新 Last-Modified（2026-03-05T12:00:00Z）。
+    let state = ServerState::new(Arc::new(body_v2.clone()), "etag-v2");
+    *state.last_modified.lock().await = "Thu, 05 Mar 2026 12:00:00 GMT".to_string();
+    let new_expected = std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_772_712_000);
+    let st = Arc::new(state);
+    let server = start_server(st).await;
+    let url = server.url("/swap.bin");
+
+    // DB 里是【旧版本】的续传现场：validator = etag-v1 + 旧 Last-Modified，
+    // 磁盘上留有 v1 的部分临时文件（单流、无 segment 行）。
+    let db = Db::open(&work_dir).await.expect("db");
+    insert_simple_task(&db, &work_dir, "mt-swap", &url, "swap.bin", 1, size as i64).await;
+    db.set_task_validator("mt-swap", "\"etag-v1\"", "Wed, 21 Oct 2025 07:28:00 GMT")
+        .await
+        .expect("set validator");
+    let temp_path = work_dir.join(format!("swap.bin{TEMP_EXT}"));
+    tokio::fs::write(&temp_path, &body_v1[..100_000])
+        .await
+        .expect("seed partial temp");
+
+    // 单流续传：If-Range("etag-v1") 与服务器 etag-v2 失配 → 200 全量 →
+    // 引擎丢弃旧前缀、从 0 重下【新版本】。
+    let client = test_client();
+    let speed_limiter = SpeedLimiter::new(0);
+    let (tx, mut rx) = mpsc::channel::<ProgressUpdate>(256);
+    let last_status = Arc::new(std::sync::atomic::AtomicI32::new(0));
+    let ls = last_status.clone();
+    let collector = tokio::spawn(async move {
+        while let Some(u) = rx.recv().await {
+            if u.status >= 3 {
+                ls.store(u.status, std::sync::atomic::Ordering::SeqCst);
+            }
+        }
+    });
+    let params = DownloadParams {
+        auto_max_connections: 0,
+        task_id: "mt-swap".to_string(),
+        url,
+        save_dir: work_dir.to_string_lossy().to_string(),
+        file_name: "swap.bin".to_string(),
+        segment_count: 1,
+        is_resume: true,
+        range_verified: true,
+        db: db.clone(),
+        client,
+        progress_tx: tx,
+        cancel_token: CancellationToken::new(),
+        speed_limiter,
+        cookies: String::new(),
+        referrer: String::new(),
+        hint_file_size: 0,
+        proxy_config: ProxyConfig::default(),
+        sink: std::sync::Arc::new(NoopTestSink),
+        selector: std::sync::Arc::new(fluxdown_engine::NoopSelection),
+        checksum: String::new(),
+        extra_headers: std::collections::HashMap::new(),
+        spec: RequestSpec::empty_get(),
+        audio_url: None,
+        use_server_time: true,
+    };
+    run_download(params).await;
+    let _ = collector.await;
+    let status = last_status.load(std::sync::atomic::Ordering::SeqCst);
+    assert_eq!(status, 3, "❌ 下载未成功");
+
+    // 磁盘内容必须是新版本（If-Range 失配后全量重下的正确性前提）。
+    let dest = work_dir.join("swap.bin");
+    let on_disk = tokio::fs::read(&dest).await.expect("read dest");
+    assert_eq!(on_disk, body_v2, "❌ 磁盘内容应为服务器上的新版本");
+
+    let mtime = tokio::fs::metadata(&dest)
+        .await
+        .expect("metadata")
+        .modified()
+        .expect("mtime");
+    assert_eq!(
+        mtime, new_expected,
+        "❌ 版本变更全量重下后，mtime 应为新版本的 Last-Modified（而非旧 validator 时间）"
     );
 
     drop(server);

--- a/native/hub/src/actors/download_actor.rs
+++ b/native/hub/src/actors/download_actor.rs
@@ -393,6 +393,10 @@ pub async fn run(db_dir: PathBuf) {
         {
             engine.manager.set_auto_retry_delay_secs(v);
         }
+        // 下载完成后是否采用服务器 Last-Modified 作为文件修改时间（默认关闭）。
+        if let Some(v) = cfg.get("use_server_time") {
+            engine.manager.set_use_server_time(v == "true");
+        }
     }
 
     if let Some(rx) = engine.manager.take_progress_rx() {
@@ -1456,6 +1460,11 @@ async fn apply_config_key(
                 log_info!("[actor] updating auto_max_connections to {}", v);
                 engine.manager.set_auto_max_connections(v);
             }
+        }
+        "use_server_time" => {
+            let v = value == "true";
+            log_info!("[actor] updating use_server_time to {}", v);
+            engine.manager.set_use_server_time(v);
         }
         "max_auto_retries" => {
             if let Ok(v) = value.parse::<i32>() {

--- a/native/server/src/actor.rs
+++ b/native/server/src/actor.rs
@@ -372,6 +372,11 @@ async fn apply_config(engine: &mut Engine, keys: &[String]) {
                     engine.manager.set_auto_max_connections(v);
                 }
             }
+            "use_server_time" => {
+                if let Some(v) = all.get(key) {
+                    engine.manager.set_use_server_time(v == "true");
+                }
+            }
             "domain_conn_caps" => {
                 // 空值 = Web 设置页「清除已学习的服务器策略」
                 if all.get(key).is_some_and(|v| v.is_empty()) {

--- a/native/server/src/main.rs
+++ b/native/server/src/main.rs
@@ -149,6 +149,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         engine.manager.set_auto_retry_delay_secs(v);
     }
+    // 下载完成后是否采用服务器 Last-Modified 作为文件修改时间（默认关闭）。
+    if let Some(v) = all_cfg.get("use_server_time") {
+        engine.manager.set_use_server_time(v == "true");
+    }
 
     // 进度上报旁路：progress_rx 独立消费（不 spawn 则无任何进度事件）。
     if let Some(rx) = engine.manager.take_progress_rx() {

--- a/web/src/components/settings/DownloadSettings.tsx
+++ b/web/src/components/settings/DownloadSettings.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import { useI18n } from '../../lib/i18n'
 import type { ConfigMap } from '../../lib/types'
 import { FsPicker } from '../dialogs/fs-picker'
-import { NumberFieldRow, SetRow, SetSelect, TextInput } from './controls'
+import { NumberFieldRow, SetRow, SetSelect, SetSwitch, TextInput } from './controls'
 
 const MB = 1024 * 1024
 
@@ -45,6 +45,7 @@ export function DownloadSettings({
   const speedBytes = Number(config.speed_limit_bytes ?? '0')
   const speedMB = speedBytes > 0 ? speedBytes / MB : 0
   const ua = config.global_user_agent ?? ''
+  const useServerTime = (config.use_server_time ?? 'false') === 'true'
 
   // 自定义模式：用户在下拉里选了"自定义"，或当前值不匹配任何预设。
   const isPreset = ua === '' || UA_PRESETS.some((p) => p.value === ua)
@@ -103,6 +104,12 @@ export function DownloadSettings({
               options={uaOptions}
             />
           </div>
+        </SetRow>
+        <SetRow title={t('set.download.serverTime')} desc={t('set.download.serverTimeDesc')}>
+          <SetSwitch
+            checked={useServerTime}
+            onCheckedChange={(v) => mutate({ use_server_time: String(v) })}
+          />
         </SetRow>
       </div>
     </>

--- a/web/src/lib/i18n.tsx
+++ b/web/src/lib/i18n.tsx
@@ -317,6 +317,9 @@ const en = {
   'set.download.uaDesc': 'Browser identity for download requests. Set to "netdisk" for Baidu Pan direct links',
   'set.download.uaDefault': 'Default (unset)',
   'set.download.uaCustomPlaceholder': 'Custom User-Agent',
+  'set.download.serverTime': 'Use server file time',
+  'set.download.serverTimeDesc':
+    "Set completed files' modified time to the server-provided Last-Modified instead of the completion time",
 
   // settings: bt
   'set.bt.desc': 'librqbit engine parameters (server side)',
@@ -658,6 +661,8 @@ const zh: Record<I18nKey, string> = {
   'set.download.uaDesc': '下载请求时使用的浏览器标识。百度网盘直链下载需设为 netdisk',
   'set.download.uaDefault': '默认（不设置）',
   'set.download.uaCustomPlaceholder': '自定义 User-Agent',
+  'set.download.serverTime': '使用服务器文件时间',
+  'set.download.serverTimeDesc': '下载完成后将文件修改时间设为服务器提供的 Last-Modified，而非下载完成时间',
 
   'set.bt.desc': 'librqbit 引擎参数（服务器端）',
   'set.bt.dht': '启用 DHT',


### PR DESCRIPTION

Closes #45

## 做了什么

新增设置「**使用服务器文件时间**」（默认关闭）：开启后，下载完成的文件会把**修改时间**设为服务器响应的 `Last-Modified` 原始时间，而不是下载完成时间。行为与 aria2 的 `--remote-time` 对齐，方便按文件时间管理版本的用户。

## 实现要点

- **引擎**：`Last-Modified` 此前已作为续传一致性 validator 被捕获和持久化，本 PR 直接复用该值——在 finalize rename 之后设置文件 mtime（`downloader.rs`）。时间戳属于尽力而为的元数据：服务器未提供、解析失败或写入失败都只记日志，绝不影响下载结果。
- **HTTP 日期解析**：覆盖 RFC 9110 允许的三种格式（IMF-fixdate / 过时 RFC 850 / asctime），复用现有 chrono 依赖，零新增依赖。解析前剥离星期字段——现实中偶见服务器生成的星期与日期不符，严格校验会整体拒绝可用时间戳（与 curl 行为一致）。
- **配置管道**：config key `use_server_time`，桌面 App 与 headless server 双侧支持启动加载 + 运行时热更新。
- **aria2 RPC 兼容**：全局选项 `remote-time` 映射到该配置，AriaNg 等客户端可直接读写。
- **UI**：设置页「下载」分类新增开关，含设置搜索索引与中英文案。

## 测试

- 单元测试：三种 HTTP 日期格式解析、错误星期的宽松解析、非法输入/纪元前时间拒绝、aria2 选项映射合法与非法值
- 集成测试（realtest）：开启时文件 mtime 精确等于服务器 `Last-Modified`，关闭时保持本地完成时间
- 存量回归全部通过（engine 549 / api 160 / hub），`cargo fmt` + `clippy -D warnings` 干净，`flutter analyze` 无新增告警

## 范围外（可后续增量）

- FTP 经 MDTM 命令获取远端时间（FTP 路径目前不填 `last_modified`，自然跳过，不受影响）
- hint 模式（浏览器扩展跳过 probe 的一次性 URL）下从首个 206 响应 latch 并持久化 validator
- Windows 创建时间：与 aria2 对齐仅设置修改时间；若期望同时设置创建时间，可在 issue 中进一步讨论
