### PR TITLE
feat(protocol): 添加 fluxdown:// 自定义协议支持（Android + 浏览器插件）

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -60,6 +60,18 @@
                 <category android:name="android.intent.category.BROWSABLE"/>
                 <data android:scheme="magnet"/>
             </intent-filter>
+            <!-- 自定义协议 fluxdown:// 唤起新建下载（与浏览器插件联动）。
+                格式：fluxdown://download?url=<encoded-url>&filename=<name>
+                浏览器插件的 enableFluxdownProtocol 开关开启后，拦截下载时
+                重定向到此协议 URL，系统（含 Android Edge/Chrome）自动唤起 FluxDown。 -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data
+                    android:scheme="fluxdown"
+                    android:host="download"/>
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/android/app/src/main/kotlin/com/fluxdown/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/fluxdown/app/MainActivity.kt
@@ -285,7 +285,7 @@ class MainActivity : FlutterActivity() {
     /**
      * 从 intent 提取可下载的 URL / magnet。
      * - ACTION_SEND：取 EXTRA_TEXT（浏览器"分享链接"）
-     * - ACTION_VIEW：取 data（magnet: 直链等）
+     * - ACTION_VIEW：取 data（magnet: 直链等；fluxdown:// 则解析 url 参数）
      * 返回 null 表示无可用内容（如首页 LAUNCHER 启动）。
      */
     private fun extractShared(intent: Intent?): String? {
@@ -293,8 +293,21 @@ class MainActivity : FlutterActivity() {
         return when (intent.action) {
             Intent.ACTION_SEND ->
                 intent.getStringExtra(Intent.EXTRA_TEXT)?.trim()?.ifEmpty { null }
-            Intent.ACTION_VIEW ->
-                intent.dataString?.trim()?.ifEmpty { null }
+            Intent.ACTION_VIEW -> {
+                val data = intent.dataString?.trim()?.ifEmpty { null } ?: return null
+                if (data.startsWith("fluxdown://", ignoreCase = true)) {
+                    // fluxdown://download?url=<encoded-url>&filename=<name>
+                    // 解析 url 参数提取真实下载地址，忽略 filename（引擎自动推断）
+                    try {
+                        val uri = Uri.parse(data)
+                        uri.getQueryParameter("url")?.trim()?.ifEmpty { null }
+                    } catch (_: Exception) {
+                        data // 解析失败时退化为原始串，由 Dart 侧容错
+                    }
+                } else {
+                    data
+                }
+            }
             else -> null
         }
     }

--- a/fluxDown/entrypoints/background.ts
+++ b/fluxDown/entrypoints/background.ts
@@ -2365,6 +2365,30 @@ export default defineBackground(() => {
     // 引擎收到后分别下载 + mux 合并。追加为末位可选参数，不影响既有调用方。
     audioUrl?: string,
   ): Promise<boolean> {
+    // === fluxdown:// 自定义协议模式 ===
+    // 启用后跳过 NMH/远端投递，直接在浏览器中打开协议 URL，
+    // 由已注册该协议的应用（如 Android FluxDown）接管下载。
+    // 协议格式：fluxdown://download?url=<encoded-url>&filename=<name>
+    // 因为不经过 NMH，Cookie/Headers 等认证信息无法携带，适用于无需登录的公开文件。
+    {
+      const protocolSettings = await getCachedSettings();
+      if (protocolSettings.enableFluxdownProtocol) {
+        const params = new URLSearchParams({ url });
+        if (filename) params.set("filename", filename);
+        const protocolUrl = `fluxdown://download?${params.toString()}`;
+        console.log(
+          "[FluxDown] Fluxdown protocol mode — opening:",
+          protocolUrl,
+        );
+        // 创建新标签页导航到协议 URL；浏览器（Chrome/Edge/Firefox）触达不到
+        // 时会在新标签页展示协议错误，对桌面用户无副作用（且开关默认关闭）。
+        browser.tabs.create({ url: protocolUrl, active: true }).catch(() => {
+          console.warn("[FluxDown] Failed to open fluxdown:// URL");
+        });
+        return true;
+      }
+    }
+
     // === 预热 NMH 链路（fire-and-forget） ===
     // App 冷启动 ~0.7-1s，下方 cookie/认证收集最多 ~500ms。先发 warmup
     // 让两者并行；App 已运行时 warmup 是 ~1ms 本地应答，无副作用。

--- a/fluxDown/entrypoints/popup/index.html
+++ b/fluxDown/entrypoints/popup/index.html
@@ -95,6 +95,16 @@
         <div class="mode-hint" data-i18n="settings.altClickHint">Press Alt+Shift+D to quickly toggle download interception</div>
         <div class="row">
           <div class="switch-info">
+            <span class="label" data-i18n="options.protocol.label">FluxDown Protocol</span>
+            <span class="hint" id="protocolHint" data-i18n="options.protocol.disabled">Off</span>
+          </div>
+          <label class="toggle">
+            <input type="checkbox" id="protocolToggle">
+            <span class="slider"></span>
+          </label>
+        </div>
+        <div class="row">
+          <div class="switch-info">
             <span class="label" data-i18n="options.general.notifyLocalTitle">Local Task Notifications</span>
           </div>
           <label class="toggle">

--- a/fluxDown/entrypoints/popup/main.ts
+++ b/fluxDown/entrypoints/popup/main.ts
@@ -41,6 +41,8 @@ const statusBadge = $('#statusBadge')!;
 const statusText = statusBadge.querySelector('.status-text')!;
 const enableToggle = $<HTMLInputElement>('#enableToggle');
 const enableHint = $('#enableHint')!;
+const protocolToggle = $<HTMLInputElement>('#protocolToggle');
+const protocolHint = $('#protocolHint')!;
 const dotVisibleToggle = $<HTMLInputElement>('#dotVisibleToggle');
 const notifyLocalToggle = $<HTMLInputElement>('#notifyLocalToggle');
 const notifyRemoteToggle = $<HTMLInputElement>('#notifyRemoteToggle');
@@ -1102,6 +1104,8 @@ async function init() {
   // 高频开关
   enableToggle.checked = settings.enabled;
   updateEnableHint(settings.enabled);
+  protocolToggle.checked = settings.enableFluxdownProtocol === true;
+  updateProtocolHint(settings.enableFluxdownProtocol === true);
   dotVisibleToggle.checked = localState?.['fluxdown_dot_visible'] !== false;
 
   // 任务发送通知开关 + 远程投递模式（与 options 页同一 settings 源，双入口镜像）
@@ -1127,6 +1131,12 @@ async function init() {
 
 function updateEnableHint(enabled: boolean) {
   enableHint.textContent = enabled ? t('switch.enabled') : t('switch.disabled');
+}
+
+function updateProtocolHint(enabled: boolean) {
+  protocolHint.textContent = enabled
+    ? t('options.protocol.enabled')
+    : t('options.protocol.disabled');
 }
 
 /** 远程模式提示 + 未验证连接时禁用非 off 选项（与 options 页同规则） */
@@ -1194,6 +1204,12 @@ themeBtn.addEventListener('click', toggleTheme);
 // 悬浮球显示/隐藏
 dotVisibleToggle.addEventListener('change', async () => {
   await browser.storage.local.set({ fluxdown_dot_visible: dotVisibleToggle.checked });
+});
+
+// fluxdown:// 自定义协议开关
+protocolToggle.addEventListener('change', async () => {
+  await saveSettings({ enableFluxdownProtocol: protocolToggle.checked });
+  updateProtocolHint(protocolToggle.checked);
 });
 
 // 任务发送通知开关（本地 / 远程分开控制）

--- a/fluxDown/package-lock.json
+++ b/fluxDown/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flux-down-extension",
-  "version": "1.0.0",
+  "version": "0.1.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flux-down-extension",
-      "version": "1.0.0",
+      "version": "0.1.28",
       "devDependencies": {
         "typescript": "^5.7.0",
         "wxt": "^0.20.14"

--- a/fluxDown/utils/locales/en.ts
+++ b/fluxDown/utils/locales/en.ts
@@ -251,6 +251,11 @@ const en: Record<MessageKey, string> = {
   "options.rules.minFileSizeDesc": "Files smaller than this are not intercepted",
   "options.rules.domainDesc": "Downloads from these domains are never intercepted",
 
+  // Custom protocol (fluxdown://)
+  "options.protocol.label": "FluxDown Protocol",
+  "options.protocol.enabled": "On — redirect to fluxdown://",
+  "options.protocol.disabled": "Off (default)",
+
   // Task completion notification (task panel)
   "notify.taskCompletedTitle": "Download Complete",
   "notify.taskCompletedDetail": "{name} has finished downloading",

--- a/fluxDown/utils/locales/zh-CN.ts
+++ b/fluxDown/utils/locales/zh-CN.ts
@@ -237,6 +237,11 @@ const zhCN = {
   "options.rules.minFileSizeDesc": "小于该大小的文件不会被拦截",
   "options.rules.domainDesc": "这些域名下的下载将不会被拦截",
 
+  // 自定义协议（fluxdown://）
+  "options.protocol.label": "FluxDown 自定义协议",
+  "options.protocol.enabled": "已启用，重定向到 fluxdown://",
+  "options.protocol.disabled": "关闭（默认）",
+
   // 任务完成通知（任务面板）
   "notify.taskCompletedTitle": "下载完成",
   "notify.taskCompletedDetail": "{name} 已下载完成",

--- a/fluxDown/utils/settings.ts
+++ b/fluxDown/utils/settings.ts
@@ -66,6 +66,17 @@ export interface FluxDownSettings {
    * remoteUrl/remoteToken 任一变更时自动复位为 false。
    */
   remoteVerified: boolean;
+
+  // === 自定义协议 ===
+
+  /**
+   * 启用 fluxdown:// 自定义协议下载。
+   * 开启后拦截下载时不再投递 NMH，而是重定向到
+   * fluxdown://download?url=... 协议 URL，由已注册该协议
+   * 的应用（如 Android FluxDown）处理。
+   * 默认关闭，仅适用于已注册协议处理器的环境（主要是 Android）。
+   */
+  enableFluxdownProtocol: boolean;
 }
 
 /**
@@ -197,6 +208,9 @@ const DEFAULT_SETTINGS: FluxDownSettings = {
   remoteUrl: "",
   remoteToken: "",
   remoteVerified: false,
+
+  // 自定义协议
+  enableFluxdownProtocol: false,
 };
 
 /**


### PR DESCRIPTION
在 Android 端注册 fluxdown:// 自定义 URL Scheme，浏览器插件新增
enableFluxdownProtocol 开关（默认关闭），开启后拦截下载时重定向到
fluxdown://download?url=... 协议 URL，由已注册该协议的应用接管。

Android:
- AndroidManifest.xml 新增 fluxdown:// 协议 intent-filter
- MainActivity.kt 的 extractShared() 解析 fluxdown:// 并提取 url 参数

Browser Extension:
- settings.ts 新增 enableFluxdownProtocol 配置项（默认 false）
- background.ts sendToFluxDown() 新增短路：协议模式跳过 NMH
- Popup 设置面板新增 FluxDown Protocol 开关（中英文 i18n）