### PR TITLE
feat(engine): 便携版数据目录整合，统一迁移至 portable_data/ 子目录

### DIFF
--- a/lib/src/services/kv_store.dart
+++ b/lib/src/services/kv_store.dart
@@ -10,7 +10,8 @@ import 'platform_utils.dart';
 
 const _tag = 'KvStore';
 
-/// 便携模式下 JSON 存储文件名（放在 [resolveDataDir] 目录下，即 exe 目录）。
+/// 便携模式下 JSON 存储文件名（放在 [resolveDataDir] 目录下，
+/// 即 `<exe_dir>/portable_data/`）。
 const _kPortableFileName = 'settings.json';
 
 /// 便携模式写盘防抖间隔。

--- a/lib/src/services/platform_utils.dart
+++ b/lib/src/services/platform_utils.dart
@@ -1,5 +1,7 @@
 import 'dart:io';
 
+import 'package:meta/meta.dart';
+
 /// Marker file name — a zero-byte file placed next to the exe by the portable
 /// ZIP distribution.  Matches the Rust-side `PORTABLE_MARKER` constant.
 const portableMarker = 'portable';
@@ -21,40 +23,117 @@ bool isPortableMode() {
   }
 }
 
+/// SQLite 主库文件名；`-wal` / `-shm` 为其伴生文件（见 `_migrateDbGroup`）。
+const _dbFile = 'flux_down.db';
+const _dbWal = 'flux_down.db-wal';
+const _dbShm = 'flux_down.db-shm';
+
+/// 独立迁移项（不含 DB 三件套——那组走 `_migrateDbGroup` 原子迁移）。
+// KEEP IN SYNC with native/engine/src/data_dir.rs KNOWN_ITEMS
+const _knownItems = [
+  'settings.json',
+  'logs',
+  'icons',
+  'bt_session',
+  'plugins',
+  'plugins-work',
+  'bin',
+];
+
+/// 迁移是否已在本进程内执行过（短路重复的路径解析调用，避免每次
+/// [resolveDataDir] 都做同步文件系统探测）。
+bool _portableMigrationDone = false;
+
 /// 将旧版便携数据（≤ v0.2.x，散落在 exe 目录根层）迁移到新的
-/// `portable_data/` 子目录。
+/// `portable_data/` 子目录。与 Rust 侧 `migrate_portable_layout` 语义一致：
 ///
-/// 幂等：目标已存在则跳过。
-void _migratePortableData(String exeDir, String newDir) {
-  Directory(newDir).createSync(recursive: true);
-  // KEEP IN SYNC with native/engine/src/data_dir.rs KNOWN_ITEMS
-  const knownItems = [
-    'flux_down.db',
-    'flux_down.db-wal',
-    'flux_down.db-shm',
-    'settings.json',
-    'logs',
-    'bt_session',
-    'plugins',
-    'plugins-work',
-    'bin',
-  ];
-  for (final name in knownItems) {
+/// - 幂等：目标已存在则跳过；
+/// - DB 三件套作为原子组迁移（WAL 持有未 checkpoint 的事务，必须与主库
+///   同进退，WAL 失败时回滚主库）；
+/// - 失败条目原地保留并落盘 `<newDir>/migration_errors.log`（GUI 进程
+///   stderr 不可见，且 LogService 尚未就绪——它反向依赖本文件解析日志目录），
+///   下次启动自动重试。
+@visibleForTesting
+void migratePortableData(String exeDir, String newDir) {
+  final failures = <String>[];
+  try {
+    Directory(newDir).createSync(recursive: true);
+  } catch (e) {
+    stderr.writeln('[便携迁移] 创建目录失败 $newDir: $e');
+    return;
+  }
+  _migrateDbGroup(exeDir, newDir, failures);
+  for (final name in _knownItems) {
     final oldPath = '$exeDir${Platform.pathSeparator}$name';
     final newPath = '$newDir${Platform.pathSeparator}$name';
-    final oldType = FileSystemEntity.typeSync(oldPath);
-    if (oldType == FileSystemEntityType.notFound) continue;
-    if (FileSystemEntity.typeSync(newPath) != FileSystemEntityType.notFound) continue;
-    try {
-      if (oldType == FileSystemEntityType.directory) {
-        Directory(oldPath).renameSync(newPath);
-      } else {
-        File(oldPath).renameSync(newPath);
-      }
-    } catch (e) {
-      // logger 未就绪 + log_service 反向依赖本文件，故用 stderr 而非 logError。
-      stderr.writeln('[便携迁移] 移动失败 $oldPath → $newPath: $e');
+    if (_exists(oldPath) && !_exists(newPath)) {
+      _rename(oldPath, newPath, failures);
     }
+  }
+  if (failures.isEmpty) return;
+  for (final msg in failures) {
+    stderr.writeln('[便携迁移] $msg');
+  }
+  _persistFailures(newDir, failures);
+}
+
+bool _exists(String path) =>
+    FileSystemEntity.typeSync(path) != FileSystemEntityType.notFound;
+
+/// rename 单个文件/目录；失败时记入 [failures] 并返回 false。
+bool _rename(String oldPath, String newPath, List<String> failures) {
+  try {
+    if (FileSystemEntity.typeSync(oldPath) == FileSystemEntityType.directory) {
+      Directory(oldPath).renameSync(newPath);
+    } else {
+      File(oldPath).renameSync(newPath);
+    }
+    return true;
+  } catch (e) {
+    failures.add('移动失败 $oldPath → $newPath: $e');
+    return false;
+  }
+}
+
+/// SQLite 三件套（主库 / WAL / SHM）原子组迁移。
+///
+/// - 旧主库不存在（含孤儿 WAL）或新主库已存在 → 整组跳过，绝不单独搬 WAL；
+/// - 主库 rename 失败 → 整组放弃；
+/// - WAL rename 失败 → 已移动的主库回滚回原位，下次启动重试整组；
+/// - SHM 是共享内存索引，SQLite 会按需重建——失败仅记录、不回滚。
+void _migrateDbGroup(String exeDir, String newDir, List<String> failures) {
+  final sep = Platform.pathSeparator;
+  final oldDb = '$exeDir$sep$_dbFile';
+  final newDb = '$newDir$sep$_dbFile';
+  if (!_exists(oldDb) || _exists(newDb)) return;
+  if (!_rename(oldDb, newDb, failures)) return;
+  final oldWal = '$exeDir$sep$_dbWal';
+  if (_exists(oldWal) && !_rename(oldWal, '$newDir$sep$_dbWal', failures)) {
+    // WAL 搬不动 → 主库回滚，保持三件套同处一地。
+    _rename(newDb, oldDb, failures);
+    return;
+  }
+  final oldShm = '$exeDir$sep$_dbShm';
+  final newShm = '$newDir$sep$_dbShm';
+  if (_exists(oldShm) && !_exists(newShm)) {
+    _rename(oldShm, newShm, failures);
+  }
+}
+
+/// 迁移失败信息落盘：`<newDir>/migration_errors.log`（追加）。
+///
+/// 放数据目录根层而非 `logs/`——迁移失败时若在此处预创建 `logs/` 目录，
+/// 会让下次启动误判 `logs` 已迁移而永久跳过它。
+void _persistFailures(String newDir, List<String> failures) {
+  try {
+    final ts = DateTime.now().toIso8601String();
+    File('$newDir${Platform.pathSeparator}migration_errors.log').writeAsStringSync(
+      failures.map((m) => '$ts [便携迁移] $m\n').join(),
+      mode: FileMode.append,
+      flush: true,
+    );
+  } catch (_) {
+    // 尽力而为：失败记录本身失败时已无处可写。
   }
 }
 
@@ -83,7 +162,10 @@ String resolveDataDir() {
   if (Platform.isWindows && isPortableMode()) {
     final exeDir = File(Platform.resolvedExecutable).parent.path;
     final newDir = '$exeDir${Platform.pathSeparator}$_portableDataDir';
-    _migratePortableData(exeDir, newDir);
+    if (!_portableMigrationDone) {
+      _portableMigrationDone = true;
+      migratePortableData(exeDir, newDir);
+    }
     return newDir;
   }
   // Windows installed mode

--- a/lib/src/services/platform_utils.dart
+++ b/lib/src/services/platform_utils.dart
@@ -4,6 +4,9 @@ import 'dart:io';
 /// ZIP distribution.  Matches the Rust-side `PORTABLE_MARKER` constant.
 const portableMarker = 'portable';
 
+/// 便携数据子目录名，位于 exe 所在目录内。
+const _portableDataDir = 'portable_data';
+
 /// Whether the current Windows installation is portable mode.
 ///
 /// Portable mode is detected by the presence of a `portable` marker file
@@ -18,17 +21,53 @@ bool isPortableMode() {
   }
 }
 
+/// 将旧版便携数据（≤ v0.2.x，散落在 exe 目录根层）迁移到新的
+/// `portable_data/` 子目录。
+///
+/// 幂等：目标已存在则跳过。
+void _migratePortableData(String exeDir, String newDir) {
+  Directory(newDir).createSync(recursive: true);
+  // KEEP IN SYNC with native/engine/src/data_dir.rs KNOWN_ITEMS
+  const knownItems = [
+    'flux_down.db',
+    'flux_down.db-wal',
+    'flux_down.db-shm',
+    'settings.json',
+    'logs',
+    'bt_session',
+    'plugins',
+    'plugins-work',
+    'bin',
+  ];
+  for (final name in knownItems) {
+    final oldPath = '$exeDir${Platform.pathSeparator}$name';
+    final newPath = '$newDir${Platform.pathSeparator}$name';
+    final oldType = FileSystemEntity.typeSync(oldPath);
+    if (oldType == FileSystemEntityType.notFound) continue;
+    if (FileSystemEntity.typeSync(newPath) != FileSystemEntityType.notFound) continue;
+    try {
+      if (oldType == FileSystemEntityType.directory) {
+        Directory(oldPath).renameSync(newPath);
+      } else {
+        File(oldPath).renameSync(newPath);
+      }
+    } catch (e) {
+      // logger 未就绪 + log_service 反向依赖本文件，故用 stderr 而非 logError。
+      stderr.writeln('[便携迁移] 移动失败 $oldPath → $newPath: $e');
+    }
+  }
+}
+
 /// Resolve the application data directory.
 ///
 /// | Platform        | Mode      | Directory                                      |
 /// |-----------------|-----------|-------------------------------------------------|
-/// | Windows         | Portable  | `<exe_dir>/`  (data travels with the app)       |
+/// | Windows         | Portable  | `<exe_dir>/portable_data/`                      |
 /// | Windows         | Installed | `%LOCALAPPDATA%\FluxDown\`                      |
 /// | Linux           | —         | `$XDG_DATA_HOME/fluxdown/`                      |
 /// | macOS           | —         | `~/Library/Application Support/fluxdown/`        |
 String resolveDataDir() {
   if (Platform.isAndroid) {
-    // 应用内部存储（无需权限）；与包名保持一致
     return '/data/data/com.fluxdown.app/files/fluxdown';
   }
   if (Platform.isLinux) {
@@ -42,7 +81,10 @@ String resolveDataDir() {
   }
   // Windows
   if (Platform.isWindows && isPortableMode()) {
-    return File(Platform.resolvedExecutable).parent.path;
+    final exeDir = File(Platform.resolvedExecutable).parent.path;
+    final newDir = '$exeDir${Platform.pathSeparator}$_portableDataDir';
+    _migratePortableData(exeDir, newDir);
+    return newDir;
   }
   // Windows installed mode
   final localAppData = Platform.environment['LOCALAPPDATA'] ??

--- a/native/engine/src/data_dir.rs
+++ b/native/engine/src/data_dir.rs
@@ -20,8 +20,13 @@
 //! ### 便携数据迁移（≤ v0.2.x → v0.3+）
 //!
 //! v0.3 以前，便携数据直接散落在 `<exe_dir>/` 根层（与 exe/DLL 混在一起）。
-//! 升级后首次启动时，旧文件自动迁移到 `portable_data/` 子目录。
-//! 迁移幂等——目标文件已存在则跳过。
+//! 升级后首次启动时，旧文件自动迁移到 `portable_data/` 子目录：
+//!
+//! - 迁移幂等——目标已存在则跳过，进程内至多执行一次；
+//! - SQLite 三件套（`flux_down.db` / `-wal` / `-shm`）作为原子组迁移，
+//!   WAL 持有未 checkpoint 的事务，绝不与主库分离；
+//! - 失败的条目原地保留并记录到 `<portable_data>/migration_errors.log`
+//!   （GUI 进程无可见 stderr），下次启动自动重试。
 
 use std::path::{Path, PathBuf};
 
@@ -179,41 +184,159 @@ fn is_portable() -> bool {
     false
 }
 
-/// 将旧版便携数据（≤ v0.2.x，散落在 exe 目录根层）迁移到新的
-/// `portable_data/` 子目录。
+/// SQLite 主库文件名；`-wal` / `-shm` 为其伴生文件（见 [`migrate_db_group`]）。
+#[cfg(any(target_os = "windows", test))]
+const DB_FILE: &str = "flux_down.db";
+#[cfg(any(target_os = "windows", test))]
+const DB_WAL: &str = "flux_down.db-wal";
+#[cfg(any(target_os = "windows", test))]
+const DB_SHM: &str = "flux_down.db-shm";
+
+/// 独立迁移项（不含 DB 三件套——那组走 [`migrate_db_group`] 原子迁移）。
+// KEEP IN SYNC with lib/src/services/platform_utils.dart knownItems
+#[cfg(any(target_os = "windows", test))]
+const KNOWN_ITEMS: &[&str] = &[
+    "settings.json",
+    "logs",
+    "icons",
+    "bt_session",
+    "plugins",
+    "plugins-work",
+    "bin",
+];
+
+/// 触发旧版便携布局（≤ v0.2.x，数据散落 exe 根层）→ `portable_data/` 的
+/// 一次性迁移（`Once` 保证进程内至多执行一次）。
 ///
-/// 幂等：目标已存在则跳过。迁移通过 `rename` 完成，成功后源文件即被移除。
+/// GUI 路径下 Dart 侧 `migratePortableData` 先行执行（`LogService` 初始化
+/// 早于 `initializeRust`），故本函数通常为 no-op；其主要价值在 CLI
+/// （`native/cli`）与 headless server 等纯 Rust 入口路径。
 ///
-/// GUI 路径下 Dart 侧 `_migratePortableData` 先于本函数执行（`main.dart`
-/// L77 `LogService.init` 早于 `initializeRust` 调用），故本函数通常 no-op；
-/// 其主要价值在 CLI（`native/cli`）与 headless server 等纯 Rust 入口路径。
+/// 失败处理：条目原地保留、写 stderr 并落盘
+/// `<new_dir>/migration_errors.log`（GUI 进程 stderr 不可见，且文件 logger
+/// 尚未初始化——`logs/` 目录本身就是迁移目标之一），下次启动自动重试。
 #[cfg(target_os = "windows")]
 fn migrate_portable_data(old_root: &Path, new_dir: &Path) {
-    let _ = std::fs::create_dir_all(new_dir);
-    // KEEP IN SYNC with lib/src/services/platform_utils.dart knownItems
-    const KNOWN_ITEMS: &[&str] = &[
-        "flux_down.db",
-        "flux_down.db-wal",
-        "flux_down.db-shm",
-        "settings.json",
-        "logs",
-        "bt_session",
-        "plugins",
-        "plugins-work",
-        "bin",
-    ];
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        let failures = migrate_portable_layout(old_root, new_dir);
+        if failures.is_empty() {
+            return;
+        }
+        for msg in &failures {
+            eprintln!("[便携迁移] {msg}");
+        }
+        persist_migration_failures(new_dir, &failures);
+    });
+}
+
+/// 执行旧便携布局 → `portable_data/` 的迁移，返回失败描述列表（空 = 全部成功）。
+///
+/// 幂等：目标已存在的条目跳过。迁移通过 `rename` 完成，成功后源文件即被移除。
+///
+/// 并发语义：旧版本进程仍在运行（DB 句柄未释放）时 `rename` 因共享冲突失败，
+/// 条目原地保留并记录，等下次启动重试；两个新版进程并发迁移无害——`rename`
+/// 原子，输家仅多一条失败记录。
+#[cfg(any(target_os = "windows", test))]
+fn migrate_portable_layout(old_root: &Path, new_dir: &Path) -> Vec<String> {
+    let mut failures = Vec::new();
+    if let Err(e) = std::fs::create_dir_all(new_dir) {
+        failures.push(format!("创建目录失败 {}: {e}", new_dir.display()));
+        return failures;
+    }
+    migrate_db_group(old_root, new_dir, &mut failures);
     for name in KNOWN_ITEMS {
         let old_path = old_root.join(name);
         let new_path = new_dir.join(name);
-        if old_path.exists() && !new_path.exists() {
-            if let Err(e) = std::fs::rename(&old_path, &new_path) {
-                eprintln!(
-                    "[便携迁移] 移动失败 {} → {}: {e}",
-                    old_path.display(),
-                    new_path.display()
-                );
-            }
+        if old_path.exists()
+            && !new_path.exists()
+            && let Err(e) = std::fs::rename(&old_path, &new_path)
+        {
+            failures.push(format!(
+                "移动失败 {} → {}: {e}",
+                old_path.display(),
+                new_path.display()
+            ));
         }
+    }
+    failures
+}
+
+/// SQLite 三件套（主库 / WAL / SHM）原子组迁移。
+///
+/// WAL 持有未 checkpoint 的最近事务，必须与主库同进退，否则新目录里的
+/// 主库会静默丢失最近提交：
+///
+/// - 旧主库不存在（含孤儿 WAL）或新主库已存在 → 整组跳过，绝不单独搬 WAL；
+/// - 主库 rename 失败 → 整组放弃；
+/// - WAL rename 失败 → 已移动的主库回滚回原位，下次启动重试整组；
+/// - SHM 是共享内存索引，SQLite 会按需重建——失败仅记录、不回滚。
+#[cfg(any(target_os = "windows", test))]
+fn migrate_db_group(old_root: &Path, new_dir: &Path, failures: &mut Vec<String>) {
+    let old_db = old_root.join(DB_FILE);
+    let new_db = new_dir.join(DB_FILE);
+    if !old_db.exists() || new_db.exists() {
+        return;
+    }
+    if let Err(e) = std::fs::rename(&old_db, &new_db) {
+        failures.push(format!(
+            "移动失败 {} → {}: {e}",
+            old_db.display(),
+            new_db.display()
+        ));
+        return;
+    }
+    let old_wal = old_root.join(DB_WAL);
+    let new_wal = new_dir.join(DB_WAL);
+    if old_wal.exists()
+        && let Err(e) = std::fs::rename(&old_wal, &new_wal)
+    {
+        failures.push(format!(
+            "移动失败 {} → {}: {e}",
+            old_wal.display(),
+            new_wal.display()
+        ));
+        // WAL 搬不动 → 主库回滚，保持三件套同处一地。
+        if let Err(e) = std::fs::rename(&new_db, &old_db) {
+            failures.push(format!(
+                "回滚失败 {} → {}: {e}",
+                new_db.display(),
+                old_db.display()
+            ));
+        }
+        return;
+    }
+    let old_shm = old_root.join(DB_SHM);
+    let new_shm = new_dir.join(DB_SHM);
+    if old_shm.exists()
+        && !new_shm.exists()
+        && let Err(e) = std::fs::rename(&old_shm, &new_shm)
+    {
+        failures.push(format!(
+            "移动失败 {} → {}: {e}",
+            old_shm.display(),
+            new_shm.display()
+        ));
+    }
+}
+
+/// 迁移失败信息落盘：`<new_dir>/migration_errors.log`（追加）。
+///
+/// 放数据目录根层而非 `logs/`——迁移失败时若在此处预创建 `logs/` 目录，
+/// 会让下次启动误判 `logs` 已迁移而永久跳过它。
+#[cfg(any(target_os = "windows", test))]
+fn persist_migration_failures(new_dir: &Path, failures: &[String]) {
+    use std::io::Write;
+    let Ok(mut file) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(new_dir.join("migration_errors.log"))
+    else {
+        return;
+    };
+    let ts = chrono::Local::now().format("%Y-%m-%d %H:%M:%S%.3f");
+    for msg in failures {
+        let _ = writeln!(file, "{ts} [便携迁移] {msg}");
     }
 }
 
@@ -224,4 +347,141 @@ fn exe_dir() -> PathBuf {
         .ok()
         .and_then(|p| p.parent().map(PathBuf::from))
         .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::{
+        DB_FILE, DB_SHM, DB_WAL, migrate_db_group, migrate_portable_layout,
+        persist_migration_failures,
+    };
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
+    fn fresh_root(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "fluxdown_portable_migrate_{name}_{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn write(path: &Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, content).unwrap();
+    }
+
+    #[test]
+    fn migrates_known_items_and_db_group() {
+        let root = fresh_root("fresh");
+        let new_dir = root.join("portable_data");
+        write(&root.join(DB_FILE), "db");
+        write(&root.join(DB_WAL), "wal");
+        write(&root.join(DB_SHM), "shm");
+        write(&root.join("settings.json"), "{}");
+        write(&root.join("icons").join("custom_icon.ico"), "ico");
+        write(&root.join("logs").join("fluxdown_2026-01-01.log"), "log");
+        // exe 根层的非数据文件（exe/DLL）不在清单内，必须原地保留。
+        write(&root.join("flux_down.exe"), "bin");
+
+        let failures = migrate_portable_layout(&root, &new_dir);
+        assert!(failures.is_empty(), "{failures:?}");
+        assert_eq!(fs::read_to_string(new_dir.join(DB_FILE)).unwrap(), "db");
+        assert_eq!(fs::read_to_string(new_dir.join(DB_WAL)).unwrap(), "wal");
+        assert_eq!(fs::read_to_string(new_dir.join(DB_SHM)).unwrap(), "shm");
+        assert!(new_dir.join("icons").join("custom_icon.ico").exists());
+        assert!(
+            new_dir
+                .join("logs")
+                .join("fluxdown_2026-01-01.log")
+                .exists()
+        );
+        assert!(!root.join(DB_FILE).exists());
+        assert!(!root.join("icons").exists());
+        assert!(root.join("flux_down.exe").exists());
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn second_run_is_noop() {
+        let root = fresh_root("idempotent");
+        let new_dir = root.join("portable_data");
+        write(&root.join(DB_FILE), "db");
+        write(&root.join("settings.json"), "{}");
+        assert!(migrate_portable_layout(&root, &new_dir).is_empty());
+        let failures = migrate_portable_layout(&root, &new_dir);
+        assert!(failures.is_empty(), "{failures:?}");
+        assert_eq!(fs::read_to_string(new_dir.join(DB_FILE)).unwrap(), "db");
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn existing_target_is_never_overwritten() {
+        let root = fresh_root("keep_target");
+        let new_dir = root.join("portable_data");
+        write(&root.join("settings.json"), "old");
+        write(&new_dir.join("settings.json"), "new");
+        let failures = migrate_portable_layout(&root, &new_dir);
+        assert!(failures.is_empty(), "{failures:?}");
+        // 新数据保留，旧文件原地不动。
+        assert_eq!(
+            fs::read_to_string(new_dir.join("settings.json")).unwrap(),
+            "new"
+        );
+        assert_eq!(
+            fs::read_to_string(root.join("settings.json")).unwrap(),
+            "old"
+        );
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn orphan_wal_is_never_moved_alone() {
+        let root = fresh_root("orphan_wal");
+        let new_dir = root.join("portable_data");
+        fs::create_dir_all(&new_dir).unwrap();
+        write(&root.join(DB_WAL), "wal");
+        let mut failures = Vec::new();
+        migrate_db_group(&root, &new_dir, &mut failures);
+        assert!(failures.is_empty(), "{failures:?}");
+        assert!(root.join(DB_WAL).exists());
+        assert!(!new_dir.join(DB_WAL).exists());
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn db_group_skipped_when_new_db_exists() {
+        let root = fresh_root("group_skip");
+        let new_dir = root.join("portable_data");
+        write(&root.join(DB_FILE), "old-db");
+        write(&root.join(DB_WAL), "old-wal");
+        write(&new_dir.join(DB_FILE), "new-db");
+        let mut failures = Vec::new();
+        migrate_db_group(&root, &new_dir, &mut failures);
+        assert!(failures.is_empty(), "{failures:?}");
+        // 新主库不被覆盖，旧三件套原地保留——绝不把旧 WAL 混到新主库旁。
+        assert_eq!(fs::read_to_string(new_dir.join(DB_FILE)).unwrap(), "new-db");
+        assert!(root.join(DB_FILE).exists());
+        assert!(root.join(DB_WAL).exists());
+        assert!(!new_dir.join(DB_WAL).exists());
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn failures_are_persisted_to_data_dir_root() {
+        let root = fresh_root("persist");
+        let new_dir = root.join("portable_data");
+        fs::create_dir_all(&new_dir).unwrap();
+        persist_migration_failures(&new_dir, &["boom".to_string()]);
+        let content = fs::read_to_string(new_dir.join("migration_errors.log")).unwrap();
+        assert!(content.contains("[便携迁移] boom"), "{content}");
+        // 不得预创建 logs/ 目录（会让下次启动误判 logs 已迁移）。
+        assert!(!new_dir.join("logs").exists());
+        let _ = fs::remove_dir_all(&root);
+    }
 }

--- a/native/engine/src/data_dir.rs
+++ b/native/engine/src/data_dir.rs
@@ -6,17 +6,22 @@
 //!
 //! | Platform        | Mode      | Directory                                      |
 //! |-----------------|-----------|-------------------------------------------------|
-//! | Windows         | Portable  | `<exe_dir>/`  (data travels with the app)       |
-//! | Windows         | Installed | `%LOCALAPPDATA%\FluxDown\`                      |
-//! | Linux           | —         | `$XDG_DATA_HOME/fluxdown/`                      |
-//! | macOS           | —         | `~/Library/Application Support/fluxdown/`        |
-//! | Android         | —         | `/data/data/<package>/files/fluxdown/`           |
+//! | Windows         | 便携版     | `<exe_dir>/portable_data/`                      |
+//! | Windows         | 安装版     | `%LOCALAPPDATA%\FluxDown\`                      |
+//! | Linux           | —          | `$XDG_DATA_HOME/fluxdown/`                      |
+//! | macOS           | —          | `~/Library/Application Support/fluxdown/`        |
+//! | Android         | —          | `/data/data/<package>/files/fluxdown/`           |
 //!
-//! ### Portable detection (Windows only)
+//! ### 便携模式检测（仅 Windows）
 //!
-//! A `portable` marker file next to the executable signals portable mode.
-//! This is consistent with the existing check in `updater.rs` and the Dart-side
-//! `_isPortableMode()` in `windows_toast_helper.dart`.
+//! exe 同目录下存在 `portable` 标记文件即视为便携模式。
+//! 与 `updater.rs` 和 Dart 侧 `isPortableMode()` 保持一致。
+//!
+//! ### 便携数据迁移（≤ v0.2.x → v0.3+）
+//!
+//! v0.3 以前，便携数据直接散落在 `<exe_dir>/` 根层（与 exe/DLL 混在一起）。
+//! 升级后首次启动时，旧文件自动迁移到 `portable_data/` 子目录。
+//! 迁移幂等——目标文件已存在则跳过。
 
 use std::path::{Path, PathBuf};
 
@@ -92,8 +97,10 @@ fn resolve_data_dir_inner() -> PathBuf {
     #[cfg(target_os = "windows")]
     {
         if is_portable() {
-            // Portable mode: data lives next to the exe.
-            return exe_dir();
+            let root = exe_dir();
+            let new_dir = root.join(PORTABLE_DATA_DIR);
+            migrate_portable_data(&root, &new_dir);
+            return new_dir;
         }
         // Installed mode: use %LOCALAPPDATA%\FluxDown (always user-writable).
         if let Some(local) = std::env::var_os("LOCALAPPDATA") {
@@ -157,6 +164,10 @@ pub fn android_package_name() -> Option<String> {
     }
 }
 
+/// 便携数据子目录名，位于 exe 所在目录内。
+#[cfg(target_os = "windows")]
+const PORTABLE_DATA_DIR: &str = "portable_data";
+
 /// Windows portable detection: `portable` marker file exists next to the exe.
 #[cfg(target_os = "windows")]
 fn is_portable() -> bool {
@@ -166,6 +177,44 @@ fn is_portable() -> bool {
         return dir.join(PORTABLE_MARKER).exists();
     }
     false
+}
+
+/// 将旧版便携数据（≤ v0.2.x，散落在 exe 目录根层）迁移到新的
+/// `portable_data/` 子目录。
+///
+/// 幂等：目标已存在则跳过。迁移通过 `rename` 完成，成功后源文件即被移除。
+///
+/// GUI 路径下 Dart 侧 `_migratePortableData` 先于本函数执行（`main.dart`
+/// L77 `LogService.init` 早于 `initializeRust` 调用），故本函数通常 no-op；
+/// 其主要价值在 CLI（`native/cli`）与 headless server 等纯 Rust 入口路径。
+#[cfg(target_os = "windows")]
+fn migrate_portable_data(old_root: &Path, new_dir: &Path) {
+    let _ = std::fs::create_dir_all(new_dir);
+    // KEEP IN SYNC with lib/src/services/platform_utils.dart knownItems
+    const KNOWN_ITEMS: &[&str] = &[
+        "flux_down.db",
+        "flux_down.db-wal",
+        "flux_down.db-shm",
+        "settings.json",
+        "logs",
+        "bt_session",
+        "plugins",
+        "plugins-work",
+        "bin",
+    ];
+    for name in KNOWN_ITEMS {
+        let old_path = old_root.join(name);
+        let new_path = new_dir.join(name);
+        if old_path.exists() && !new_path.exists() {
+            if let Err(e) = std::fs::rename(&old_path, &new_path) {
+                eprintln!(
+                    "[便携迁移] 移动失败 {} → {}: {e}",
+                    old_path.display(),
+                    new_path.display()
+                );
+            }
+        }
+    }
 }
 
 /// Returns the exe's parent directory, falling back to CWD or ".".

--- a/native/engine/src/logger.rs
+++ b/native/engine/src/logger.rs
@@ -3,7 +3,7 @@
 //! - 日志目录：由 `data_dir::resolve_data_dir()` 决定，加 `/logs` 后缀
 //!   - Linux: `~/.local/share/fluxdown/logs/`
 //!   - macOS: `~/Library/Application Support/fluxdown/logs/`
-//!   - Windows 便携版: `<exe_dir>/logs/`
+//!   - Windows 便携版: `<exe_dir>/portable_data/logs/`
 //!   - Windows 安装版: `%LOCALAPPDATA%/FluxDown/logs/`
 //! - 文件名：`fluxdown_YYYY-MM-DD.log`，分卷为 `fluxdown_YYYY-MM-DD.N.log`（与 Dart 端完全一致）
 //! - 两端都以 append 模式写入，POSIX `O_APPEND` 保证单次 write 原子性

--- a/test/portable_migration_test.dart
+++ b/test/portable_migration_test.dart
@@ -1,0 +1,92 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flux_down/src/services/platform_utils.dart';
+
+/// 便携数据迁移（旧根层布局 → portable_data/）行为测试。
+/// 与 native/engine/src/data_dir.rs 的 tests 覆盖同一组语义。
+void main() {
+  late Directory root;
+  late String exeDir;
+  late String newDir;
+  final sep = Platform.pathSeparator;
+
+  setUp(() {
+    root = Directory.systemTemp.createTempSync('fluxdown_portable_migrate_');
+    exeDir = root.path;
+    newDir = '$exeDir${sep}portable_data';
+  });
+
+  tearDown(() {
+    try {
+      root.deleteSync(recursive: true);
+    } catch (_) {}
+  });
+
+  void write(String relative, String content) {
+    final file = File('$exeDir$sep$relative');
+    file.parent.createSync(recursive: true);
+    file.writeAsStringSync(content);
+  }
+
+  String read(String path) => File(path).readAsStringSync();
+
+  test('首迁：DB 三件套 + 清单条目全部移入，非数据文件原地保留', () {
+    write('flux_down.db', 'db');
+    write('flux_down.db-wal', 'wal');
+    write('flux_down.db-shm', 'shm');
+    write('settings.json', '{}');
+    write('icons${sep}custom_icon.ico', 'ico');
+    write('logs${sep}fluxdown_2026-01-01.log', 'log');
+    write('flux_down.exe', 'bin');
+
+    migratePortableData(exeDir, newDir);
+
+    expect(read('$newDir${sep}flux_down.db'), 'db');
+    expect(read('$newDir${sep}flux_down.db-wal'), 'wal');
+    expect(read('$newDir${sep}flux_down.db-shm'), 'shm');
+    expect(File('$newDir${sep}icons${sep}custom_icon.ico').existsSync(), isTrue);
+    expect(
+      File('$newDir${sep}logs${sep}fluxdown_2026-01-01.log').existsSync(),
+      isTrue,
+    );
+    expect(File('$exeDir${sep}flux_down.db').existsSync(), isFalse);
+    expect(Directory('$exeDir${sep}icons').existsSync(), isFalse);
+    // exe 根层的非数据文件不在清单内，必须原地保留。
+    expect(File('$exeDir${sep}flux_down.exe').existsSync(), isTrue);
+  });
+
+  test('幂等：第二次运行为 no-op', () {
+    write('flux_down.db', 'db');
+    write('settings.json', '{}');
+    migratePortableData(exeDir, newDir);
+    migratePortableData(exeDir, newDir);
+    expect(read('$newDir${sep}flux_down.db'), 'db');
+  });
+
+  test('目标已存在：新数据保留，旧文件原地不动', () {
+    write('settings.json', 'old');
+    write('portable_data${sep}settings.json', 'new');
+    migratePortableData(exeDir, newDir);
+    expect(read('$newDir${sep}settings.json'), 'new');
+    expect(read('$exeDir${sep}settings.json'), 'old');
+  });
+
+  test('孤儿 WAL 绝不单独搬运', () {
+    write('flux_down.db-wal', 'wal');
+    migratePortableData(exeDir, newDir);
+    expect(File('$exeDir${sep}flux_down.db-wal').existsSync(), isTrue);
+    expect(File('$newDir${sep}flux_down.db-wal').existsSync(), isFalse);
+  });
+
+  test('新主库已存在：旧三件套整组原地保留，不混搬 WAL', () {
+    write('flux_down.db', 'old-db');
+    write('flux_down.db-wal', 'old-wal');
+    write('portable_data${sep}flux_down.db', 'new-db');
+    migratePortableData(exeDir, newDir);
+    expect(read('$newDir${sep}flux_down.db'), 'new-db');
+    expect(File('$exeDir${sep}flux_down.db').existsSync(), isTrue);
+    expect(File('$exeDir${sep}flux_down.db-wal').existsSync(), isTrue);
+    expect(File('$newDir${sep}flux_down.db-wal').existsSync(), isFalse);
+  });
+}


### PR DESCRIPTION
## 背景

Windows 便携版（v0.2.x）持久化数据直接散落在 exe 根层，与 DLL、Flutter 构建产物混在一起，目录杂乱且与 Scoop persist 语义不匹配。v0.3 起统一收进 portable_data/ 子目录，首次启动自动迁移旧数据。

关联 Issue：#91

## 改动

| 文件 | 改动 |
|------|------|
| native/engine/src/data_dir.rs (+71/-14) | 便携路径 exe_dir() → exe_dir().join("portable_data")，新增 migrate_portable_data() |
| lib/src/services/platform_utils.dart (+48/-2) | Dart 侧对称实现 |

## 关键设计

- **幂等迁移**：9 类数据文件（db/settings/logs/bt_session/plugins/plugins-work/bin），目标已存在则跳过
- **时序安全**：rename 前先 create_dir_all，确保首次启动目标目录已存在
- **双端覆盖**：Dart 侧先执行（main.dart L77），Rust 侧后执行（L270）通常 no-op；CLI/headless 纯 Rust 入口由 Rust 侧覆盖
- **零扩散**：所有下游通过 resolve_data_dir() 获取路径，改入口即全局生效
- **不影响安装版**：非便携模式仍走 %LOCALAPPDATA%\FluxDown 
## 验证

| 检查项 | 结果 |
|--------|------|
| cargo clippy -p fluxdown_engine -- -D warnings | ✅ 通过 |
| flutter analyze | ✅ 零新增 issue |
| Windows 便携版 10 项手工测试 | ✅ 10/10 通过 |
| 设置持久化往返（theme_mode / window_state） | ✅ 正确 |
| CLI --local 模式 | ✅ 写入 portable_data/ 下 DB |
| 安装版回归 | ✅ 路径未受影响 |