### PR TITLE
fix(settings): persist .torrent association opt-out so toggle-off sticks

### DIFF
--- a/lib/src/models/settings_provider.dart
+++ b/lib/src/models/settings_provider.dart
@@ -63,6 +63,10 @@ class SettingsProvider extends ChangeNotifier {
   // 文件关联
   bool _torrentAssocPrompted = false; // 是否已弹窗提示过文件关联
   bool _torrentAssociated = false; // .torrent 文件是否已关联到 FluxDown
+  // User explicitly turned association OFF (persisted). Needed because on
+  // Linux .deb installs the system-wide MIME registration is root-owned and
+  // cannot be removed, so the live query alone can never report false.
+  bool _torrentAssocUserDisabled = false;
 
   // 代理设置
   String _proxyMode = 'none'; // none / system / manual
@@ -1016,10 +1020,16 @@ class SettingsProvider extends ChangeNotifier {
 
   /// 设置或取消 .torrent 文件关联。
   /// 乐观更新 UI，Rust 回传真实状态后会校正。
+  ///
+  /// Toggling OFF records a persisted opt-out so the live status reported
+  /// back by Rust cannot clobber the user's choice (see
+  /// [handleFileAssociationStatus]); toggling ON clears it.
   void setFileAssociation(bool enable) {
     logInfo('Settings', 'setFileAssociation: enable=$enable');
     _torrentAssociated = enable;
+    _torrentAssocUserDisabled = !enable;
     notifyListeners();
+    _saveToRust('torrent_assoc_user_disabled', (!enable).toString());
     SetFileAssociation(enable: enable).sendSignalToRust();
   }
 
@@ -1125,10 +1135,25 @@ class SettingsProvider extends ChangeNotifier {
   }
 
   void _onFileAssocStatus(RustSignalPack<FileAssociationStatus> pack) {
-    final associated = pack.message.isAssociated;
-    logInfo('Settings', 'file association status: $associated');
-    if (_torrentAssociated != associated) {
-      _torrentAssociated = associated;
+    handleFileAssociationStatus(pack.message.isAssociated);
+  }
+
+  /// Applies a live .torrent association status reported by Rust.
+  /// Exposed for tests; production code receives it via the signal stream.
+  ///
+  /// A persisted user opt-out gates the reported status: on Linux .deb
+  /// installs the system-wide MIME registration is root-owned, so after
+  /// `disassociate()` the live query still resolves FluxDown and would
+  /// otherwise snap a user-requested OFF back to ON (issue #98).
+  @visibleForTesting
+  void handleFileAssociationStatus(bool associated) {
+    final effective = associated && !_torrentAssocUserDisabled;
+    logInfo(
+      'Settings',
+      'file association status: $associated (effective: $effective)',
+    );
+    if (_torrentAssociated != effective) {
+      _torrentAssociated = effective;
       notifyListeners();
     }
   }
@@ -1143,7 +1168,13 @@ class SettingsProvider extends ChangeNotifier {
   }
 
   void _onConfigLoaded(RustSignalPack<ConfigLoaded> pack) {
-    final entries = pack.message.entries;
+    applyLoadedConfig(pack.message.entries);
+  }
+
+  /// Applies config entries loaded from Rust.
+  /// Exposed for tests; production code receives them via the signal stream.
+  @visibleForTesting
+  void applyLoadedConfig(List<ConfigEntry> entries) {
     logInfo('Settings', '_onConfigLoaded: ${entries.length} entries');
     String legacyOpenDirCmd = '';
     // 追踪 reveal_file_cmd 键是否出现在配置中（区分「从未设置」与「已清空」）。
@@ -1219,6 +1250,8 @@ class SettingsProvider extends ChangeNotifier {
           _ed2kListenPort = int.tryParse(entry.value) ?? 0;
         case 'torrent_assoc_prompted':
           _torrentAssocPrompted = entry.value == 'true';
+        case 'torrent_assoc_user_disabled':
+          _torrentAssocUserDisabled = entry.value == 'true';
         case 'notify_on_complete':
           _notifyOnComplete = entry.value != 'false'; // 默认 true
         case 'silent_download_enabled':

--- a/test/torrent_assoc_toggle_test.dart
+++ b/test/torrent_assoc_toggle_test.dart
@@ -1,0 +1,112 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:launch_at_startup/launch_at_startup.dart';
+
+import 'package:flux_down/src/bindings/bindings.dart';
+import 'package:flux_down/src/models/settings_provider.dart';
+
+/// Repro for zerx-lab/FluxDown#98: on Linux (.deb install) the
+/// "Associate .torrent files" toggle cannot be turned off.
+///
+/// The .deb registers `com.fluxdown.app.desktop` system-wide (root-owned),
+/// so after `disassociate()` strips the per-user mimeapps.list override,
+/// `xdg-mime query default application/x-bittorrent` STILL resolves FluxDown.
+/// The actor immediately re-queries and sends `FileAssociationStatus
+/// { is_associated: true }`, which clobbers the user's OFF choice and snaps
+/// the switch back on within ~50ms.
+///
+/// Expected behavior: an explicit user opt-out wins over a live query that
+/// can never go false, and it survives a restart via a persisted config key.
+void main() {
+  final binding = TestWidgetsFlutterBinding.ensureInitialized();
+
+  // SettingsProvider's constructor syncs auto-startup state over the
+  // `launch_at_startup` method channel; mock it so the async sync completes.
+  launchAtStartup.setup(
+    appName: 'FluxDownTest',
+    appPath: Platform.resolvedExecutable,
+  );
+  binding.defaultBinaryMessenger.setMockMethodCallHandler(
+    const MethodChannel('launch_at_startup'),
+    (call) async => call.method == 'launchAtStartupIsEnabled' ? false : null,
+  );
+
+  ConfigEntry entry(String key, String value) =>
+      ConfigEntry(key: key, value: value);
+
+  // Calls SettingsProvider.setFileAssociation tolerating the ArgumentError
+  // from `sendSignalToRust` (the Rust dylib is not loaded under
+  // `flutter test`). All in-memory state mutations must complete before the
+  // fire-and-forget signal sends, so the observable state is unaffected.
+  void userToggles(SettingsProvider settings, bool enable) {
+    try {
+      settings.setFileAssociation(enable);
+    } on ArgumentError {
+      // rinf native library unavailable in the test VM.
+    }
+  }
+
+  test(
+    'user toggle-off sticks even when the live query still reports associated',
+    () {
+      final settings = SettingsProvider(enableFileAssoc: false);
+      addTearDown(settings.dispose);
+
+      // Association is on (e.g. user enabled it earlier; Rust confirmed).
+      userToggles(settings, true);
+      settings.handleFileAssociationStatus(true);
+      expect(settings.torrentAssociated, isTrue);
+
+      // User turns the toggle OFF.
+      userToggles(settings, false);
+      expect(settings.torrentAssociated, isFalse);
+
+      // Linux reality: disassociate() cannot remove the root-owned
+      // system-wide registration, so the immediate re-query reports true.
+      settings.handleFileAssociationStatus(true);
+      expect(
+        settings.torrentAssociated,
+        isFalse,
+        reason: 'a user-requested OFF must not be clobbered by a live query '
+            'that can never go false on a .deb install',
+      );
+    },
+  );
+
+  test('persisted opt-out survives restart (config reload + startup query)',
+      () {
+    // Fresh provider simulating an app restart after the user opted out.
+    final settings = SettingsProvider(enableFileAssoc: false);
+    addTearDown(settings.dispose);
+
+    settings.applyLoadedConfig([entry('torrent_assoc_user_disabled', 'true')]);
+    // The startup association check still sees the system registration.
+    settings.handleFileAssociationStatus(true);
+    expect(
+      settings.torrentAssociated,
+      isFalse,
+      reason: 'the opt-out persisted before restart must keep the toggle OFF',
+    );
+  });
+
+  test('without an opt-out the live status remains authoritative', () {
+    final settings = SettingsProvider(enableFileAssoc: false);
+    addTearDown(settings.dispose);
+
+    // Fresh install: an installer-made association is reported and shown.
+    settings.handleFileAssociationStatus(true);
+    expect(settings.torrentAssociated, isTrue);
+
+    // User opts in, but the OS later reports the association was lost
+    // (possible on Windows/macOS) -> reflect reality.
+    userToggles(settings, true);
+    settings.handleFileAssociationStatus(false);
+    expect(settings.torrentAssociated, isFalse);
+
+    // And a later true report turns it back on (no stale opt-out in the way).
+    settings.handleFileAssociationStatus(true);
+    expect(settings.torrentAssociated, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #98 — on Linux .deb installs, the Settings → General "Associate .torrent files" toggle could not be turned off: it flipped OFF and immediately reverted to ON.

## Root cause

The toggle was a live mirror of `xdg-mime query default application/x-bittorrent` with no persisted user preference. The .deb registers the handler system-wide in `/usr/share/applications/` (root-owned, not removable by the unprivileged app), so `disassociate()` — which only strips the user's `~/.config/mimeapps.list` line — can never make the query return false. The hub actor re-queries immediately after disassociating and echoes `FileAssociationStatus { is_associated: true }`, which clobbered the user's OFF in `SettingsProvider` (matches the issue log: every `setFileAssociation: enable=false` is followed by `file association status: true`).

## Fix

Persist an explicit user opt-out (config key `torrent_assoc_user_disabled`, written on toggle-off, cleared on toggle-on) and gate the effective status: `effective = live_query && !opted_out`. One source file changed: `lib/src/models/settings_provider.dart`. Windows/macOS keep live-query behavior when no opt-out is set (pinned by a dedicated regression test). The OS-level associate/disassociate calls are unchanged.

Behavioral note: while opted out, an association re-created externally (e.g. via OS settings) shows as OFF in FluxDown until the user toggles ON in-app, which clears the opt-out.

## Commits

- `db333c8` `fix(settings)` — self-contained, touches only `settings_provider.dart`, applies cleanly on its own.
- `fde1253` `test(settings)` — regression tests only (`test/torrent_assoc_toggle_test.dart`); skippable when cherry-picking.

## Verification

- Red→green proven: with the fix commit reverted, the repro test fails with `Expected: false / Actual: <true>` (the status-echo clobber); at HEAD all 3 repro tests pass.
- Full suite: `flutter test` → 227 passed. `flutter analyze` → no new issues (5 pre-existing, all in untouched files).