### PR TITLE
fix(engine): apply BT file selection at add time to avoid librqbit Initializing race

### DIFF
--- a/native/engine/src/bt_downloader.rs
+++ b/native/engine/src/bt_downloader.rs
@@ -3297,6 +3297,15 @@ async fn bt_download_inner(p: BtInnerParams) -> Result<(), DownloadError> {
                     );
                     log_info!("[BT] task={} {}", short_id(&task_id), &msg);
                     let _ = shared_bt.delete_task(&task_id, false).await;
+                    // Pause landed during teardown — keep status=2 (the bad
+                    // handle is already gone; resume re-adds with AtAdd).
+                    if cancelled.load(Ordering::SeqCst) {
+                        log_info!(
+                            "[BT] task={} cancelled during selection-failure teardown → keeping paused state",
+                            short_id(&task_id)
+                        );
+                        return Err(DownloadError::Cancelled);
+                    }
                     let _ = db.update_task_status(&task_id, STATUS_ERROR, &msg).await;
                     let _ = progress_tx
                         .send(ProgressUpdate {

--- a/native/engine/src/bt_downloader.rs
+++ b/native/engine/src/bt_downloader.rs
@@ -2540,6 +2540,122 @@ async fn verify_staged_pieces(
     .map_err(|e| format!("verification task failed: {e}"))?
 }
 
+/// How a BT file selection reaches librqbit. A known subset is baked into
+/// `AddTorrentOptions.only_files` at add time because `update_only_files` is
+/// rejected while librqbit is Initializing; a dialog selection stays post-add (#90).
+#[derive(Debug, PartialEq, Eq)]
+pub enum BtSelectionStrategy {
+    All,
+    AtAdd(Vec<usize>),
+    PostAdd,
+}
+
+impl BtSelectionStrategy {
+    pub fn only_files_for_add(&self) -> Option<Vec<usize>> {
+        match self {
+            BtSelectionStrategy::AtAdd(subset) => Some(subset.clone()),
+            BtSelectionStrategy::All | BtSelectionStrategy::PostAdd => None,
+        }
+    }
+}
+
+/// Build the librqbit add options for a fresh torrent. Baking the known subset
+/// into `only_files` here (not via a post-add `update_only_files`) is the fix
+/// for the Initializing race (#90); the production add site must go through this.
+pub fn build_add_torrent_options(
+    strategy: &BtSelectionStrategy,
+    output_folder: String,
+) -> AddTorrentOptions {
+    AddTorrentOptions {
+        overwrite: true,
+        output_folder: Some(output_folder),
+        only_files: strategy.only_files_for_add(),
+        ..Default::default()
+    }
+}
+
+/// Negative indices (the `-1` cancel sentinel or corrupt entries) are not valid
+/// librqbit file ids and are dropped; an empty result means "not yet known".
+pub fn decide_bt_selection_strategy(
+    skip_file_selection: bool,
+    pre_selected_indices: &[i32],
+) -> BtSelectionStrategy {
+    if skip_file_selection {
+        return BtSelectionStrategy::All;
+    }
+    let subset: Vec<usize> = pre_selected_indices
+        .iter()
+        .copied()
+        .filter(|&i| i >= 0)
+        .map(|i| i as usize)
+        .collect();
+    if subset.is_empty() {
+        // Empty input (dialog pending) or all-negative garbage (e.g. a corrupt
+        // `[-2]`): never bake an empty `only_files`; defer to the post-add flow (#90).
+        BtSelectionStrategy::PostAdd
+    } else {
+        debug_assert!(!subset.is_empty(), "AtAdd must never carry an empty subset");
+        BtSelectionStrategy::AtAdd(subset)
+    }
+}
+
+/// Wait out librqbit's `Initializing` window (which rejects `update_only_files`),
+/// then apply the post-add selection. Returns `true` once applied (#90).
+async fn apply_only_files_after_init(
+    session: &Arc<Session>,
+    handle: &BtHandle,
+    only: &HashSet<usize>,
+    task_id: &str,
+    cancelled: &AtomicBool,
+) -> bool {
+    const MAX_ATTEMPTS: u32 = 5;
+    for attempt in 1..=MAX_ATTEMPTS {
+        if cancelled.load(Ordering::SeqCst) {
+            return false;
+        }
+        // librqbit's `wait_until_initialized` blocks for the whole hash-check;
+        // race it against cancellation (polling the same AtomicBool the add loop
+        // uses) so a pause/cancel is not stuck behind it (#90). BoxFuture is
+        // Unpin, so `&mut` in select! needs no extra pinning.
+        let mut init = handle.wait_until_initialized();
+        let initialized = loop {
+            tokio::select! {
+                biased;
+                r = &mut init => break r,
+                _ = tokio::time::sleep(Duration::from_millis(200)) => {
+                    if cancelled.load(Ordering::SeqCst) {
+                        return false;
+                    }
+                }
+            }
+        };
+        if let Err(e) = initialized {
+            // A wait error is fatal: surface it via the caller's error path
+            // instead of falling through and downloading unselected files (#90).
+            log_info!(
+                "[BT] task={} wait_until_initialized failed before applying file selection: {}",
+                short_id(task_id),
+                e
+            );
+            return false;
+        }
+        match session.update_only_files(handle, only).await {
+            Ok(()) => return true,
+            Err(e) => {
+                log_info!(
+                    "[BT] task={} update_only_files attempt {}/{} failed: {} — waiting for init and retrying",
+                    short_id(task_id),
+                    attempt,
+                    MAX_ATTEMPTS,
+                    e
+                );
+                tokio::time::sleep(Duration::from_millis(200)).await;
+            }
+        }
+    }
+    false
+}
+
 async fn bt_download_inner(p: BtInnerParams) -> Result<(), DownloadError> {
     let BtInnerParams {
         task_id,
@@ -2562,6 +2678,9 @@ async fn bt_download_inner(p: BtInnerParams) -> Result<(), DownloadError> {
     // entirely because librqbit already retains the previous update_only_files
     // state internally.
     let had_existing_handle = existing_handle.is_some();
+    let selection_strategy =
+        decide_bt_selection_strategy(skip_file_selection, &pre_selected_indices);
+
     // -----------------------------------------------------------------------
     // Phase 1: Send initial file name from dn= parameter so user sees something
     // -----------------------------------------------------------------------
@@ -2635,11 +2754,16 @@ async fn bt_download_inner(p: BtInnerParams) -> Result<(), DownloadError> {
             shared_bt.clear_stale_fastresume(&hash);
         }
         let stage_dir_str = stage_dir.to_string_lossy().into_owned();
-        let add_opts = AddTorrentOptions {
-            overwrite: true,
-            output_folder: Some(stage_dir_str),
-            ..Default::default()
-        };
+        // A known subset must be baked into add options here; a post-add update
+        // is rejected while librqbit is Initializing (#90).
+        if let Some(subset) = selection_strategy.only_files_for_add() {
+            log_info!(
+                "[BT] task={} baking {} pre-selected file(s) into add options (only_files) to survive librqbit init",
+                short_id(&task_id),
+                subset.len()
+            );
+        }
+        let add_opts = build_add_torrent_options(&selection_strategy, stage_dir_str);
 
         log_info!(
             "[BT] task={} adding torrent to shared session (metadata resolution may take a while)...",
@@ -3117,26 +3241,69 @@ async fn bt_download_inner(p: BtInnerParams) -> Result<(), DownloadError> {
         return Err(DownloadError::Cancelled);
     }
 
-    // If user selected nothing (should not happen in practice), fall back to
-    // downloading all files.
-    let selected_indices = if selected_indices.is_empty() {
+    // If the selection is empty or holds no valid (non-negative) index — e.g. a
+    // corrupt persisted `[-2]`; the `-1` cancel sentinel already returned above —
+    // fall back to all files rather than applying an empty only_files that would
+    // download nothing (#90).
+    let selected_indices = if selected_indices.iter().all(|&i| i < 0) {
         (0..file_count as i32).collect::<Vec<_>>()
     } else {
         selected_indices
     };
 
-    // Restrict to selected files when only a subset was chosen.
-    // Path R (had_existing_handle) produces selected_indices.len() == file_count
-    // so update_only_files is skipped — librqbit already has the right state.
-    // Path A and Path B both need to apply the selection on a fresh add_torrent.
+    // Path R (had_existing_handle) yields selected_indices.len() == file_count,
+    // so this block is skipped — librqbit already has the right state.
     if selected_indices.len() < file_count {
-        let only: HashSet<usize> = selected_indices.iter().map(|&i| i as usize).collect();
-        if let Err(e) = session.update_only_files(&handle, &only).await {
-            log_info!(
-                "[BT] task={} update_only_files error: {} — downloading all",
-                short_id(&task_id),
-                e
-            );
+        match selection_strategy {
+            // Already applied at add time (#90); skip the post-add update.
+            BtSelectionStrategy::AtAdd(_) => {
+                log_info!(
+                    "[BT] task={} file selection ({} file(s)) applied at add time — skipping post-add update_only_files",
+                    short_id(&task_id),
+                    selected_indices.len()
+                );
+            }
+            // Dialog selection known only post-add: wait out Initializing, then apply (#90).
+            BtSelectionStrategy::All | BtSelectionStrategy::PostAdd => {
+                let only: HashSet<usize> = selected_indices
+                    .iter()
+                    .copied()
+                    .filter(|&i| i >= 0)
+                    .map(|i| i as usize)
+                    .collect();
+                if apply_only_files_after_init(&session, &handle, &only, &task_id, &cancelled).await
+                {
+                    log_info!(
+                        "[BT] task={} file selection applied post-add ({} file(s))",
+                        short_id(&task_id),
+                        only.len()
+                    );
+                } else if cancelled.load(Ordering::SeqCst) {
+                    return Err(DownloadError::Cancelled);
+                } else {
+                    // Surface the failure instead of silently downloading unselected
+                    // files (#90); mirrors the other fatal BT setup error paths.
+                    let msg = format!(
+                        "failed to apply file selection ({} file(s)) after librqbit init",
+                        only.len()
+                    );
+                    log_info!("[BT] task={} {}", short_id(&task_id), &msg);
+                    let _ = db.update_task_status(&task_id, STATUS_ERROR, &msg).await;
+                    let _ = progress_tx
+                        .send(ProgressUpdate {
+                            task_id: task_id.clone(),
+                            downloaded_bytes: 0,
+                            total_bytes,
+                            status: STATUS_ERROR,
+                            error_message: msg.clone(),
+                            file_name: resolved_name.clone(),
+                            segment_details: None,
+                            ..Default::default()
+                        })
+                        .await;
+                    return Err(DownloadError::Other(msg));
+                }
+            }
         }
     }
 

--- a/native/engine/src/bt_downloader.rs
+++ b/native/engine/src/bt_downloader.rs
@@ -3392,6 +3392,14 @@ async fn bt_download_inner(p: BtInnerParams) -> Result<(), DownloadError> {
     let _ = db
         .update_task_file_info(&task_id, &resolved_name, total_bytes)
         .await;
+    // Don't clobber a pause (status=2) that landed during the awaits above.
+    if cancelled.load(Ordering::SeqCst) {
+        log_info!(
+            "[BT] task={} cancelled before downloading-status write → keeping paused state",
+            short_id(&task_id)
+        );
+        return Err(DownloadError::Cancelled);
+    }
     let _ = db
         .update_task_status(&task_id, STATUS_DOWNLOADING, "")
         .await;

--- a/native/engine/src/bt_downloader.rs
+++ b/native/engine/src/bt_downloader.rs
@@ -3287,6 +3287,8 @@ async fn bt_download_inner(p: BtInnerParams) -> Result<(), DownloadError> {
                         only.len()
                     );
                 } else if cancelled.load(Ordering::SeqCst) {
+                    // Drop the handle with unapplied only_files so resume re-adds via AtAdd.
+                    let _ = shared_bt.delete_task(&task_id, false).await;
                     return Err(DownloadError::Cancelled);
                 } else {
                     // Surface the failure instead of silently downloading unselected

--- a/native/engine/src/bt_downloader.rs
+++ b/native/engine/src/bt_downloader.rs
@@ -2629,6 +2629,9 @@ async fn apply_only_files_after_init(
                 }
             }
         };
+        if cancelled.load(Ordering::SeqCst) {
+            return false;
+        }
         if let Err(e) = initialized {
             // A wait error is fatal: surface it via the caller's error path
             // instead of falling through and downloading unselected files (#90).
@@ -2640,7 +2643,12 @@ async fn apply_only_files_after_init(
             return false;
         }
         match session.update_only_files(handle, only).await {
-            Ok(()) => return true,
+            Ok(()) => {
+                if cancelled.load(Ordering::SeqCst) {
+                    return false;
+                }
+                return true;
+            }
             Err(e) => {
                 log_info!(
                     "[BT] task={} update_only_files attempt {}/{} failed: {} — waiting for init and retrying",
@@ -3288,6 +3296,7 @@ async fn bt_download_inner(p: BtInnerParams) -> Result<(), DownloadError> {
                         only.len()
                     );
                     log_info!("[BT] task={} {}", short_id(&task_id), &msg);
+                    let _ = shared_bt.delete_task(&task_id, false).await;
                     let _ = db.update_task_status(&task_id, STATUS_ERROR, &msg).await;
                     let _ = progress_tx
                         .send(ProgressUpdate {

--- a/native/engine/tests/bt_file_selection.rs
+++ b/native/engine/tests/bt_file_selection.rs
@@ -1,0 +1,86 @@
+//! Regression test for zerx-lab/FluxDown#90: a known BT file selection must be
+//! baked into `AddTorrentOptions.only_files` at add time. librqbit rejects
+//! `update_only_files` while `Initializing`, so a post-add update silently
+//! dropped the subset and downloaded every file.
+
+use fluxdown_engine::bt_downloader::{
+    BtSelectionStrategy, build_add_torrent_options, decide_bt_selection_strategy,
+};
+
+// Path A: partial subset known before add → must be applied at add time.
+#[test]
+fn partial_pre_selection_is_applied_at_add_time() {
+    let selected: Vec<i32> = vec![0, 1, 2, 3, 4, 5, 6, 7, 8];
+
+    let strategy = decide_bt_selection_strategy(false, &selected);
+
+    assert_eq!(
+        strategy,
+        BtSelectionStrategy::AtAdd(vec![0, 1, 2, 3, 4, 5, 6, 7, 8])
+    );
+    assert_eq!(
+        strategy.only_files_for_add(),
+        Some(vec![0, 1, 2, 3, 4, 5, 6, 7, 8])
+    );
+}
+
+// Path S: user confirmed "all files" → no restriction.
+#[test]
+fn all_files_confirmed_needs_no_restriction() {
+    let strategy = decide_bt_selection_strategy(true, &[]);
+
+    assert_eq!(strategy, BtSelectionStrategy::All);
+    assert_eq!(strategy.only_files_for_add(), None);
+}
+
+// Path B: first-time magnet, dialog pending → selection applied post-add.
+#[test]
+fn unknown_selection_is_applied_post_add() {
+    let strategy = decide_bt_selection_strategy(false, &[]);
+
+    assert_eq!(strategy, BtSelectionStrategy::PostAdd);
+    assert_eq!(strategy.only_files_for_add(), None);
+}
+
+// The -1 cancel sentinel and corrupt negatives are never valid file ids.
+#[test]
+fn cancel_sentinel_and_negatives_are_never_baked_as_files() {
+    let strategy = decide_bt_selection_strategy(false, &[-1]);
+
+    assert_eq!(strategy, BtSelectionStrategy::PostAdd);
+    assert_eq!(strategy.only_files_for_add(), None);
+}
+
+// Corrupt persisted selection like [-2] (non-empty, all-negative, NOT the -1
+// cancel sentinel): the negative filter empties it, so it must fall back to a
+// safe strategy — never AtAdd(empty), which would silently download nothing (#90).
+#[test]
+fn corrupt_negative_preselection_never_downloads_none() {
+    let strategy = decide_bt_selection_strategy(false, &[-2]);
+
+    assert_ne!(strategy, BtSelectionStrategy::AtAdd(vec![]));
+    assert_eq!(strategy, BtSelectionStrategy::PostAdd);
+    assert_eq!(strategy.only_files_for_add(), None);
+}
+
+// Guards the real add-site wiring: production builds its add options via
+// build_add_torrent_options, so reverting only_files there turns this red.
+#[test]
+fn build_add_options_bakes_known_subset_into_only_files() {
+    let strategy = decide_bt_selection_strategy(false, &[0, 1, 2, 3, 4, 5, 6, 7, 8]);
+
+    let opts = build_add_torrent_options(&strategy, "stage".to_string());
+
+    assert_eq!(opts.only_files, Some(vec![0, 1, 2, 3, 4, 5, 6, 7, 8]));
+    assert_eq!(opts.output_folder.as_deref(), Some("stage"));
+}
+
+// All / PostAdd must leave only_files unset so librqbit fetches every file.
+#[test]
+fn build_add_options_leaves_only_files_unset_when_not_preselected() {
+    let all = build_add_torrent_options(&BtSelectionStrategy::All, "stage".to_string());
+    assert_eq!(all.only_files, None);
+
+    let post = build_add_torrent_options(&BtSelectionStrategy::PostAdd, "stage".to_string());
+    assert_eq!(post.only_files, None);
+}


### PR DESCRIPTION
## Root cause

`add_torrent` was called with `only_files: None` and the user's file selection was applied only afterwards via `update_only_files`. librqbit returns the handle while its async hash-check is still running (`Initializing` state) and rejects selection updates in that state (`can't update initializing torrent`). The engine swallowed that error and fell back to downloading **all** files — on every start and every pause→resume, since each resume re-adds and re-checks. Large torrents lose the race every time; small ones sometimes won it, which is why this went unnoticed.

## Fix

- Selections known before add (pre-selected / resume with persisted selection) are baked into `AddTorrentOptions.only_files` at add time — librqbit's race-free path.
- The interactive-dialog path (selection arrives after add) now waits out `Initializing` via `wait_until_initialized` and applies with bounded retry; a persistent failure errors the task instead of silently downloading everything.
- Lifecycle hardening around the new wait/apply: a concurrent pause can no longer be overwritten back to downloading (or to error), and no torrent handle with wrong/unapplied selection survives for a cached-handle resume.

## Verification

- Red→green: with the fix commits reverted, the new `bt_file_selection` tests fail; at HEAD all 7 pass.
- `cargo test -p fluxdown_engine`: 614 passed. `cargo clippy -p fluxdown_engine --all-targets -- -D warnings` and `cargo fmt --check` clean.
- The reported scenario (pre-selected subset + multi-minute hash check) now takes the add-time path; the `update_only_files error: … — downloading all` log line can no longer occur for known selections.

Fixes #90