### PR TITLE
fix(macos): re-sync popup Flutter view scale when presented on screen (#100)

### DIFF
--- a/macos/Runner/PopupWindowHost.swift
+++ b/macos/Runner/PopupWindowHost.swift
@@ -68,6 +68,8 @@ final class PopupWindowHost: NSObject, NSWindowDelegate {
     private var pendingPayload: String?
     /// reveal 兜底定时器（show 时武装；reveal 到达 / 隐藏时作废）。
     private var revealFallback: DispatchWorkItem?
+    /// Backing-change observer for the persistent popup window (#100).
+    private var backingObserver: NSObjectProtocol?
 
     // -------------------------------------------------------------------
     // 主引擎侧接线
@@ -153,6 +155,25 @@ final class PopupWindowHost: NSObject, NSWindowDelegate {
         guard let win = window else { return }
         win.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
+        syncPopupScale()
+    }
+
+    /// #100: the first frame renders while the window is ordered out, latching
+    /// the FlutterView layer at the wrong contentsScale, and AppKit does not
+    /// reliably re-push backing metrics when the window lands on a HiDPI screen.
+    /// Runs on EVERY present and on backing changes; the metrics re-push is
+    /// unconditional because the engine may hold a stale pixel ratio even when
+    /// the layer scale already looks right.
+    private func syncPopupScale() {
+        guard let win = window, let view = popupController?.view else { return }
+        // Ordered-out windows report screen == nil; fall back like repositionCentered.
+        let scale = win.screen?.backingScaleFactor
+            ?? NSScreen.screens.first?.backingScaleFactor
+            ?? win.backingScaleFactor
+        if let layer = view.layer, layer.contentsScale != scale {
+            layer.contentsScale = scale
+        }
+        view.viewDidChangeBackingProperties()
     }
 
     /// 统一隐藏入口：隐藏窗口并作废 pending 的 reveal 兜底。
@@ -237,6 +258,15 @@ final class PopupWindowHost: NSObject, NSWindowDelegate {
         childChannel = channel
 
         window = win
+
+        // queue nil = synchronous on the posting (main) thread.
+        backingObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didChangeBackingPropertiesNotification,
+            object: win,
+            queue: nil
+        ) { [weak self] _ in
+            self?.syncPopupScale()
+        }
         return win
     }
 

--- a/scripts/test_popup_present_scale.sh
+++ b/scripts/test_popup_present_scale.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Repro/regression test for issue #100 (popup black frame): compiles the real
+# macos/Runner/PopupWindowHost.swift against a minimal FlutterMacOS shim and
+# drives the show/reveal handshake with a real NSWindow. No xcodebuild needed.
+set -eu
+cd "$(dirname "$0")/.."
+
+BUILD_DIR="$(mktemp -d)"
+trap 'rm -rf "$BUILD_DIR"' EXIT
+
+swiftc -c test/macos/flutter_macos_shim.swift \
+    -parse-as-library -module-name FlutterMacOS \
+    -emit-module -emit-module-path "$BUILD_DIR/FlutterMacOS.swiftmodule" \
+    -o "$BUILD_DIR/FlutterMacOS.o"
+
+swiftc -I "$BUILD_DIR" \
+    test/macos/popup_present_scale_test.swift \
+    macos/Runner/PopupWindowHost.swift \
+    "$BUILD_DIR/FlutterMacOS.o" \
+    -o "$BUILD_DIR/popup_present_scale_test"
+
+"$BUILD_DIR/popup_present_scale_test"

--- a/test/macos/flutter_macos_shim.swift
+++ b/test/macos/flutter_macos_shim.swift
@@ -1,0 +1,93 @@
+// Test-only FlutterMacOS stand-in: just enough API surface for
+// macos/Runner/PopupWindowHost.swift to compile under bare swiftc.
+
+import Cocoa
+
+public typealias FlutterResult = (Any?) -> Void
+
+public let FlutterMethodNotImplemented = NSObject()
+
+public protocol FlutterBinaryMessenger: AnyObject {}
+
+public final class ShimMessenger: NSObject, FlutterBinaryMessenger {
+    override public init() {}
+}
+
+public final class FlutterError: NSObject {
+    public let code: String
+    public let message: String?
+    public let details: Any?
+    public init(code: String, message: String?, details: Any?) {
+        self.code = code
+        self.message = message
+        self.details = details
+    }
+}
+
+public final class FlutterMethodCall: NSObject {
+    public let method: String
+    public let arguments: Any?
+    public init(methodName: String, arguments: Any?) {
+        self.method = methodName
+        self.arguments = arguments
+    }
+}
+
+public final class FlutterMethodChannel: NSObject {
+    public private(set) static var registry: [String: FlutterMethodChannel] = [:]
+
+    public let name: String
+    public private(set) var handler: ((FlutterMethodCall, @escaping FlutterResult) -> Void)?
+    public private(set) var invocations: [(method: String, arguments: Any?)] = []
+
+    public init(name: String, binaryMessenger: FlutterBinaryMessenger) {
+        self.name = name
+        super.init()
+        FlutterMethodChannel.registry[name] = self
+    }
+
+    public func setMethodCallHandler(_ handler: ((FlutterMethodCall, @escaping FlutterResult) -> Void)?) {
+        self.handler = handler
+    }
+
+    public func invokeMethod(_ method: String, arguments: Any?) {
+        invocations.append((method, arguments))
+    }
+}
+
+public final class FlutterDartProject: NSObject {
+    public var dartEntrypointArguments: [String]?
+    override public init() {}
+}
+
+public final class FlutterEngine: NSObject {
+    public let binaryMessenger: FlutterBinaryMessenger = ShimMessenger()
+}
+
+/// Stand-in FlutterView: records forced backing-metrics re-pushes. The real
+/// FlutterView re-pushes window metrics to the engine (pixel ratio included)
+/// from viewDidChangeBackingProperties.
+public final class RecordingFlutterView: NSView {
+    public private(set) var metricsPushes = 0
+    public func resetMetricsPushes() { metricsPushes = 0 }
+    override public func viewDidChangeBackingProperties() {
+        super.viewDidChangeBackingProperties()
+        metricsPushes += 1
+    }
+}
+
+public class FlutterViewController: NSViewController {
+    public let engine = FlutterEngine()
+
+    public init(project: FlutterDartProject) {
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    public required init?(coder: NSCoder) {
+        return nil
+    }
+
+    override public func loadView() {
+        view = RecordingFlutterView(frame: NSRect(x: 0, y: 0, width: 520, height: 600))
+    }
+}

--- a/test/macos/popup_present_scale_test.swift
+++ b/test/macos/popup_present_scale_test.swift
@@ -1,0 +1,92 @@
+// Repro for issue #100 (popup black frame): the popup engine renders its first
+// frame while the window is ordered out, latching the view layer at the wrong
+// contentsScale. On present (and on later backing changes) the host must
+// re-assert the layer scale from the window's real scale AND force a
+// backing-metrics re-push so the engine re-reads the pixel ratio.
+// Drives the real PopupWindowHost via its method channels, compiled against
+// the FlutterMacOS shim, with a real borderless NSWindow.
+
+import Cocoa
+import FlutterMacOS
+
+@main
+struct PopupPresentScaleTest {
+    static var failures = 0
+
+    static func check(_ ok: Bool, _ label: String) {
+        print("\(ok ? "PASS" : "FAIL"): \(label)")
+        if !ok { failures += 1 }
+    }
+
+    static func call(_ channel: FlutterMethodChannel, _ method: String, _ arguments: Any?) {
+        guard let handler = channel.handler else {
+            print("FATAL: no handler on channel \(channel.name)")
+            exit(2)
+        }
+        handler(FlutterMethodCall(methodName: method, arguments: arguments)) { _ in }
+    }
+
+    static func main() {
+        let app = NSApplication.shared
+        app.setActivationPolicy(.accessory)
+
+        PopupWindowHost.shared.register(with: ShimMessenger())
+        guard let hostChannel = FlutterMethodChannel.registry["fluxdown/popup_host"] else {
+            print("FATAL: fluxdown/popup_host not registered")
+            exit(2)
+        }
+
+        // Cycle 1: create + present once so first-attach backing latching settles;
+        // the regression is about re-presents where AppKit reports no change.
+        call(hostChannel, "show", "{}")
+        guard let childChannel = FlutterMethodChannel.registry["fluxdown/popup_child"] else {
+            print("FATAL: fluxdown/popup_child not registered")
+            exit(2)
+        }
+        call(childChannel, "reveal", ["height": 400.0])
+
+        guard
+            let win = app.windows.first(where: { $0.contentViewController is FlutterViewController }),
+            let view = win.contentViewController?.view as? RecordingFlutterView
+        else {
+            print("FATAL: popup window/view not found")
+            exit(2)
+        }
+        check(win.isVisible, "sanity: popup window is visible after reveal")
+
+        call(hostChannel, "close", nil)
+
+        // Cycle 2: latch a wrong scale while hidden (the ordered-out raster
+        // state from the bug), then reveal — present must re-sync.
+        call(hostChannel, "show", "{}")
+        let landingScale = NSScreen.screens.first?.backingScaleFactor ?? win.backingScaleFactor
+        let wrongScale: CGFloat = landingScale == 1.0 ? 2.0 : 1.0
+        view.layer?.contentsScale = wrongScale
+        view.resetMetricsPushes()
+
+        call(childChannel, "reveal", ["height": 400.0])
+
+        let truth = win.screen?.backingScaleFactor
+            ?? NSScreen.screens.first?.backingScaleFactor
+            ?? win.backingScaleFactor
+        let presentedScale = view.layer?.contentsScale ?? -1
+        check(presentedScale == truth,
+              "present re-asserts layer.contentsScale to window scale (got \(presentedScale), want \(truth))")
+        check(view.metricsPushes >= 1,
+              "present forces a backing-metrics re-push (got \(view.metricsPushes) pushes)")
+
+        // Backing change while the persistent window lives on (display move /
+        // scale change) must re-sync too.
+        view.layer?.contentsScale = wrongScale
+        view.resetMetricsPushes()
+        NotificationCenter.default.post(name: NSWindow.didChangeBackingPropertiesNotification, object: win)
+        let notifiedScale = view.layer?.contentsScale ?? -1
+        check(notifiedScale == truth,
+              "backing-change notification re-asserts layer scale (got \(notifiedScale), want \(truth))")
+        check(view.metricsPushes >= 1,
+              "backing-change notification forces a metrics re-push (got \(view.metricsPushes) pushes)")
+
+        call(hostChannel, "close", nil)
+        exit(failures == 0 ? 0 : 1)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #100 — on macOS with a scaled external display as primary, the download-confirmation popup rendered as a mostly black window: content at half scale in the top-left, hit-testing offset to full-window positions.

**Root cause:** the popup's second Flutter engine renders its first frame while its borderless window is still ordered out (reveal handshake, 5a08f0a), latching `layer.contentsScale = 1.0`. After `makeKeyAndOrderFront` onto a 2× display, AppKit raises the layer scale but the embedder never re-pushes window metrics — a 1× raster on a 2× layer, while hit-testing stays in logical coordinates. The main window is unaffected because it is on screen before it renders.

**Fix:** `syncPopupScale()` in `PopupWindowHost.swift` — re-asserts `layer.contentsScale` from the window's real backing scale (no-op when already correct) and forces a metrics re-push via `viewDidChangeBackingProperties()` after every present, plus a `didChangeBackingPropertiesNotification` observer for later display/scale changes. Mirrors the existing `FloatingBallPanel` scale handling.

## Test

- Standalone behavioral repro (`scripts/test_popup_present_scale.sh`: swiftc + minimal FlutterMacOS shim, drives the real show→reveal handshake on the unmodified production file). Red before the fix (scale stuck at 1.0, zero metrics pushes), green after.
- `flutter test`: 227 passed. `flutter build macos --debug`: clean.

Note: the test commit precedes the fix commit and is file-disjoint — the fix commit cherry-picks and builds standalone; the test commit alone is deliberately red.