### PR TITLE
feat(engine,ui): surface source page URL in task details

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -162,6 +162,7 @@
     "infoPath": "Path",
     "infoError": "Error",
     "infoUrl": "URL",
+    "infoSourcePage": "Source",
     "resumingClickPause": "Resuming... (click to pause)",
     "dynamicSplit": "Split",
     "splitCount": "{total} ({proactive} proactive · {reactive} reactive)",

--- a/assets/i18n/zh.json
+++ b/assets/i18n/zh.json
@@ -162,6 +162,7 @@
     "infoPath": "路径",
     "infoError": "错误",
     "infoUrl": "地址",
+    "infoSourcePage": "来源页",
     "resumingClickPause": "恢复中...（点击暂停）",
     "dynamicSplit": "拆分",
     "splitCount": "{total} 次（主动 {proactive} · 响应 {reactive}）",

--- a/lib/src/i18n/translations.dart
+++ b/lib/src/i18n/translations.dart
@@ -261,6 +261,7 @@ class S {
   String get infoPath => _r('infoPath');
   String get infoError => _r('infoError');
   String get infoUrl => _r('infoUrl');
+  String get infoSourcePage => _r('infoSourcePage');
   String get resumingClickPause => _r('resumingClickPause');
   String get dynamicSplit => _r('dynamicSplit');
   String splitCount(int total, int reactive, int proactive) => _r(

--- a/lib/src/models/download_task.dart
+++ b/lib/src/models/download_task.dart
@@ -254,6 +254,9 @@ class DownloadTask {
   /// 展示与「创建后改线程数」编辑。与运行时实际分片数 [segments] 不同。
   final int configuredSegments;
 
+  /// Source page URL captured by the browser extension (empty = none).
+  final String referrer;
+
   DownloadTask({
     required this.id,
     required this.url,
@@ -273,6 +276,7 @@ class DownloadTask {
     this.fileNameConfirmed = false,
     this.fileMissing = false,
     this.configuredSegments = 0,
+    this.referrer = '',
     this.completedAt,
     DateTime? createdAt,
   }) : createdAt = createdAt ?? DateTime.now();
@@ -298,6 +302,7 @@ class DownloadTask {
       fileNameConfirmed: hasName,
       fileMissing: info.fileMissing,
       configuredSegments: info.segments,
+      referrer: info.referrer,
       createdAt: seconds > 0
           ? DateTime.fromMillisecondsSinceEpoch(seconds * 1000)
           : DateTime.now(),
@@ -327,6 +332,7 @@ class DownloadTask {
     bool? fileNameConfirmed,
     bool? fileMissing,
     int? configuredSegments,
+    String? referrer,
     DateTime? createdAt,
     DateTime? completedAt,
   }) {
@@ -349,6 +355,7 @@ class DownloadTask {
       fileNameConfirmed: fileNameConfirmed ?? this.fileNameConfirmed,
       fileMissing: fileMissing ?? this.fileMissing,
       configuredSegments: configuredSegments ?? this.configuredSegments,
+      referrer: referrer ?? this.referrer,
       createdAt: createdAt ?? this.createdAt,
       completedAt: clearCompletedAt ? null : (completedAt ?? this.completedAt),
     );

--- a/lib/src/widgets/detail_panel.dart
+++ b/lib/src/widgets/detail_panel.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
+import 'package:url_launcher/url_launcher.dart';
 import 'flux_sonner.dart';
 import '../bindings/bindings.dart';
 import '../models/download_controller.dart';
@@ -496,6 +497,7 @@ class _DetailPanelState extends State<DetailPanel> {
         if (splitCount > 0) _buildSplitInfoRow(c, task),
         _buildInfoRow(currentS.infoPath, task.saveDir, c),
         _buildUrlRow(c, task.url),
+        if (task.referrer.isNotEmpty) _buildSourcePageRow(c, task.referrer),
         if (task.errorMessage.isNotEmpty)
           _buildErrorRow(c, task.errorMessage),
       ],
@@ -764,6 +766,51 @@ class _DetailPanelState extends State<DetailPanel> {
           ),
           const SizedBox(width: 4),
           _CopyValueButton(value: url, color: c.textMuted),
+        ],
+      ),
+    );
+  }
+
+  /// Source page (referrer) row — copy + open in browser.
+  Widget _buildSourcePageRow(AppColors c, String referrer) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 10),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 60,
+            child: Text(
+              currentS.infoSourcePage,
+              style: TextStyle(fontSize: 11, color: c.textMuted),
+            ),
+          ),
+          Expanded(
+            child: Text(
+              referrer,
+              maxLines: 3,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                fontSize: 11,
+                color: c.textSecondary,
+                fontFeatures: const [FontFeature.tabularFigures()],
+              ),
+            ),
+          ),
+          const SizedBox(width: 4),
+          _CopyValueButton(value: referrer, color: c.textMuted),
+          ShadButton.ghost(
+            onPressed: () => launchUrl(Uri.parse(referrer)),
+            size: ShadButtonSize.sm,
+            width: 24,
+            height: 24,
+            padding: EdgeInsets.zero,
+            child: Icon(
+              LucideIcons.externalLink,
+              size: 12,
+              color: c.textMuted,
+            ),
+          ),
         ],
       ),
     );

--- a/native/api/src/aria2.rs
+++ b/native/api/src/aria2.rs
@@ -760,6 +760,7 @@ mod tests {
             checksum: String::new(),
             file_missing: false,
             completed_at: String::new(),
+            referrer: String::new(),
         }
     }
 

--- a/native/api/src/jsonrpc.rs
+++ b/native/api/src/jsonrpc.rs
@@ -733,6 +733,7 @@ mod tests {
             checksum: String::new(),
             file_missing: false,
             completed_at: String::new(),
+            referrer: String::new(),
         }
     }
 

--- a/native/api/src/mcp.rs
+++ b/native/api/src/mcp.rs
@@ -346,6 +346,7 @@ mod tests {
             checksum: String::new(),
             file_missing: false,
             completed_at: String::new(),
+            referrer: String::new(),
         }
     }
 

--- a/native/api/src/tests.rs
+++ b/native/api/src/tests.rs
@@ -261,6 +261,7 @@ fn sample_task(id: &str, status: i32) -> TaskDto {
         checksum: String::new(),
         file_missing: false,
         completed_at: String::new(),
+        referrer: String::new(),
     }
 }
 

--- a/native/api/src/types.rs
+++ b/native/api/src/types.rs
@@ -158,6 +158,8 @@ pub struct DownloadRequest {
 ///     file_missing: false,
 ///     completed_at: String::new(),
 ///     segments: 0,
+///     queue_order: 0,
+///     referrer: String::new(),
 /// };
 /// let dto = TaskDto::from(info);
 /// assert_eq!(dto.task_id, "t1");
@@ -191,6 +193,9 @@ pub struct TaskDto {
     /// 记录下载真正完成（status→3）的时刻，不含插件 hook 后处理耗时。
     #[serde(default)]
     pub completed_at: String,
+    /// Source page URL captured by the browser extension (empty = none).
+    #[serde(default)]
+    pub referrer: String,
 }
 
 impl From<fluxdown_engine::model::TaskInfo> for TaskDto {
@@ -210,6 +215,7 @@ impl From<fluxdown_engine::model::TaskInfo> for TaskDto {
             checksum: t.checksum,
             file_missing: t.file_missing,
             completed_at: t.completed_at,
+            referrer: t.referrer,
         }
     }
 }
@@ -754,6 +760,7 @@ mod tests {
             checksum: String::new(),
             file_missing: false,
             completed_at: String::new(),
+            referrer: String::new(),
         };
         let v = serde_json::to_value(&dto).unwrap();
         assert_eq!(v["taskId"], "t1");

--- a/native/api/tests/task_referrer.rs
+++ b/native/api/tests/task_referrer.rs
@@ -1,0 +1,31 @@
+//! Repro for issue #111: `TaskDto` must expose the task referrer on the wire.
+
+use fluxdown_api::types::TaskDto;
+use fluxdown_engine::model::TaskInfo;
+
+#[test]
+fn task_dto_json_carries_referrer() {
+    let info = TaskInfo {
+        task_id: "t1".to_string(),
+        url: "https://example.com/f.zip".to_string(),
+        file_name: "f.zip".to_string(),
+        save_dir: "/tmp".to_string(),
+        status: 2,
+        downloaded_bytes: 10,
+        total_bytes: 100,
+        error_message: String::new(),
+        created_at: "1700000000".to_string(),
+        proxy_url: String::new(),
+        queue_id: String::new(),
+        checksum: String::new(),
+        file_missing: false,
+        completed_at: String::new(),
+        segments: 0,
+        queue_order: 0,
+        referrer: "https://example.com/page".to_string(),
+    };
+    let dto = TaskDto::from(info);
+    assert_eq!(dto.referrer, "https://example.com/page");
+    let json = serde_json::to_string(&dto).expect("serialize");
+    assert!(json.contains(r#""referrer":"https://example.com/page""#));
+}

--- a/native/engine/src/db.rs
+++ b/native/engine/src/db.rs
@@ -254,10 +254,11 @@ fn task_from_row(row: &AnyRow) -> Result<TaskInfo, sqlx::Error> {
         completed_at: row.try_get("completed_at").unwrap_or_default(),
         segments: row.try_get("segments").unwrap_or(0),
         queue_order: row.try_get("queue_order").unwrap_or(0),
+        referrer: row.try_get("referrer").unwrap_or_default(),
     })
 }
 
-const TASK_COLUMNS: &str = "id, url, file_name, save_dir, status, downloaded_bytes, total_bytes, error_message, created_at, proxy_url, queue_id, checksum, file_missing, completed_at, segments, queue_order";
+const TASK_COLUMNS: &str = "id, url, file_name, save_dir, status, downloaded_bytes, total_bytes, error_message, created_at, proxy_url, queue_id, checksum, file_missing, completed_at, segments, queue_order, referrer";
 
 impl Db {
     /// 在 `dir` 目录下打开（不存在则创建）SQLite 数据库 `flux_down.db`。

--- a/native/engine/src/model.rs
+++ b/native/engine/src/model.rs
@@ -59,6 +59,8 @@ pub struct TaskInfo {
     /// 队列内启动顺序（越小越先启动）。0 = 未显式排序，按 `created_at`
     /// 先来先启动；>0 为显式顺序（`reorder_queue_tasks` 或建任务时追加）。
     pub queue_order: i32,
+    /// Source page URL captured by the browser extension (empty = none).
+    pub referrer: String,
 }
 
 /// 命名队列元数据。字段对应 `hub::signals::QueueInfo`。

--- a/native/engine/tests/task_referrer_snapshot.rs
+++ b/native/engine/tests/task_referrer_snapshot.rs
@@ -1,0 +1,37 @@
+//! Repro for issue #111: the outbound task snapshot (DB load path used at
+//! startup) must carry the persisted referrer so hosts can show the source page.
+
+use fluxdown_engine::db::Db;
+
+#[tokio::test]
+async fn loaded_task_snapshot_carries_referrer() {
+    let db = Db::connect("sqlite::memory:").await.expect("open db");
+    db.insert_task(
+        "t1",
+        "https://example.com/f.zip",
+        "f.zip",
+        "/tmp",
+        0,
+        0,
+        "",
+        "main",
+        "",
+        0,
+    )
+    .await
+    .expect("insert task");
+    db.set_task_request_context("t1", "", "https://example.com/page", "")
+        .await
+        .expect("set request context");
+
+    let tasks = db.load_all_tasks().await.expect("load all");
+    assert_eq!(tasks.len(), 1);
+    assert_eq!(tasks[0].referrer, "https://example.com/page");
+
+    let one = db
+        .load_task_by_id("t1")
+        .await
+        .expect("load by id")
+        .expect("task exists");
+    assert_eq!(one.referrer, "https://example.com/page");
+}

--- a/native/hub/src/native_messaging.rs
+++ b/native/hub/src/native_messaging.rs
@@ -930,6 +930,7 @@ mod tests {
             checksum: String::new(),
             file_missing: false,
             completed_at: String::new(),
+            referrer: String::new(),
         }
     }
 

--- a/native/hub/src/signal_bridge.rs
+++ b/native/hub/src/signal_bridge.rs
@@ -28,6 +28,7 @@ impl From<model::TaskInfo> for signals::TaskInfo {
             completed_at: t.completed_at,
             segments: t.segments,
             queue_order: t.queue_order,
+            referrer: t.referrer,
         }
     }
 }

--- a/native/hub/src/signals/mod.rs
+++ b/native/hub/src/signals/mod.rs
@@ -316,6 +316,9 @@ pub struct TaskInfo {
     /// 队列内启动顺序（越小越先启动）。0 = 未显式排序（按创建时间）。
     #[serde(default)]
     pub queue_order: i32,
+    /// Source page URL captured by the browser extension (empty = none).
+    #[serde(default)]
+    pub referrer: String,
 }
 
 /// 文件跟踪：一批已完成任务的「文件已丢失」标志变化（Rust → Dart）。

--- a/native/server/src/wire.rs
+++ b/native/server/src/wire.rs
@@ -655,6 +655,7 @@ mod tests {
             checksum: String::new(),
             file_missing: false,
             completed_at: String::new(),
+            referrer: String::new(),
         }
     }
 

--- a/native/server/src/ws_hub.rs
+++ b/native/server/src/ws_hub.rs
@@ -818,6 +818,7 @@ mod tests {
             completed_at: String::new(),
             segments: 0,
             queue_order: 0,
+            referrer: String::new(),
         }]));
 
         let snap = hub.live_speeds_snapshot();
@@ -843,6 +844,7 @@ mod tests {
             completed_at: String::new(),
             segments: 0,
             queue_order: 0,
+            referrer: String::new(),
         }
     }
 

--- a/test/task_referrer_test.dart
+++ b/test/task_referrer_test.dart
@@ -1,0 +1,56 @@
+// Repro for issue #111: DownloadTask must carry the referrer from TaskInfo
+// and periodic TaskProgress updates must not clobber it.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flux_down/src/bindings/bindings.dart';
+import 'package:flux_down/src/models/download_task.dart';
+
+void main() {
+  TaskInfo makeInfo() => const TaskInfo(
+    taskId: 't1',
+    url: 'https://example.com/f.zip',
+    fileName: 'f.zip',
+    saveDir: '/tmp',
+    status: 2,
+    downloadedBytes: 10,
+    totalBytes: 100,
+    errorMessage: '',
+    createdAt: '1700000000',
+    proxyUrl: '',
+    queueId: '',
+    checksum: '',
+    fileMissing: false,
+    completedAt: '',
+    segments: 0,
+    queueOrder: 0,
+    referrer: 'https://example.com/page',
+  );
+
+  test('fromTaskInfo maps referrer', () {
+    final task = DownloadTask.fromTaskInfo(makeInfo());
+    expect(task.referrer, 'https://example.com/page');
+  });
+
+  test('applyProgress preserves referrer', () {
+    final task = DownloadTask.fromTaskInfo(makeInfo());
+    final updated = task.applyProgress(
+      const TaskProgress(
+        taskId: 't1',
+        status: 1,
+        downloadedBytes: 50,
+        totalBytes: 100,
+        speed: 1000,
+        fileName: 'f.zip',
+        saveDir: '/tmp',
+        url: 'https://example.com/f.zip',
+        errorMessage: '',
+      ),
+    );
+    expect(updated.referrer, 'https://example.com/page');
+  });
+
+  test('copyWith preserves and overrides referrer', () {
+    final task = DownloadTask.fromTaskInfo(makeInfo());
+    expect(task.copyWith(status: TaskStatus.paused).referrer,
+        'https://example.com/page');
+  });
+}

--- a/website/public/openapi.json
+++ b/website/public/openapi.json
@@ -1848,7 +1848,7 @@
       },
       "TaskDto": {
         "type": "object",
-        "description": "任务信息（`GET /api/v1/tasks`、`GET /api/v1/tasks/{id}` 响应）。\n\n# Examples\n\n```\nuse fluxdown_api::types::TaskDto;\nuse fluxdown_engine::model::TaskInfo;\n\nlet info = TaskInfo {\n    task_id: \"t1\".to_string(),\n    url: \"https://example.com/f.zip\".to_string(),\n    file_name: \"f.zip\".to_string(),\n    save_dir: \"/tmp\".to_string(),\n    status: 1,\n    downloaded_bytes: 10,\n    total_bytes: 100,\n    error_message: String::new(),\n    created_at: \"1700000000\".to_string(),\n    proxy_url: String::new(),\n    queue_id: String::new(),\n    checksum: String::new(),\n    file_missing: false,\n    completed_at: String::new(),\n    segments: 0,\n};\nlet dto = TaskDto::from(info);\nassert_eq!(dto.task_id, \"t1\");\nlet json = serde_json::to_string(&dto).unwrap();\nassert!(json.contains(\"\\\"taskId\\\":\\\"t1\\\"\"));\n```",
+        "description": "任务信息（`GET /api/v1/tasks`、`GET /api/v1/tasks/{id}` 响应）。\n\n# Examples\n\n```\nuse fluxdown_api::types::TaskDto;\nuse fluxdown_engine::model::TaskInfo;\n\nlet info = TaskInfo {\n    task_id: \"t1\".to_string(),\n    url: \"https://example.com/f.zip\".to_string(),\n    file_name: \"f.zip\".to_string(),\n    save_dir: \"/tmp\".to_string(),\n    status: 1,\n    downloaded_bytes: 10,\n    total_bytes: 100,\n    error_message: String::new(),\n    created_at: \"1700000000\".to_string(),\n    proxy_url: String::new(),\n    queue_id: String::new(),\n    checksum: String::new(),\n    file_missing: false,\n    completed_at: String::new(),\n    segments: 0,\n    queue_order: 0,\n    referrer: String::new(),\n};\nlet dto = TaskDto::from(info);\nassert_eq!(dto.task_id, \"t1\");\nlet json = serde_json::to_string(&dto).unwrap();\nassert!(json.contains(\"\\\"taskId\\\":\\\"t1\\\"\"));\n```",
         "required": [
           "taskId",
           "url",
@@ -1897,6 +1897,10 @@
           "queueId": {
             "type": "string",
             "description": "命名队列 ID（空 = 默认队列）。"
+          },
+          "referrer": {
+            "type": "string",
+            "description": "Source page URL captured by the browser extension (empty = none)."
           },
           "saveDir": {
             "type": "string"


### PR DESCRIPTION
Feat #111

Threads the already-persisted `tasks.referrer` (source page URL captured by the browser extension) through the outbound read path: engine `TaskInfo` → hub signal → Dart `DownloadTask` → a new "Source page" row in the task detail panel (copy + open-in-browser, hidden when empty). REST `TaskDto` and the OpenAPI spec gain the field for parity. i18n: en + zh.

Notes:
- Commit structure follows the test-first convention: one test-only commit (red standalone, safe to skip when cherry-picking), then two code commits that build independently on develop.
- The api code commit also fixes a pre-existing red doctest in `native/api/src/types.rs` (example literal was missing `queue_order`) — required to keep the api suite green.
- Verified: cargo tests (engine 615 / hub 39 / api 172 passed), `flutter test` (266 passed), `flutter analyze` (no new issues), macOS debug build, plus a manual end-to-end check on a real task.