### PR TITLE
feat(widgets): support tree and list views for BitTorrent file selection

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -277,6 +277,8 @@
     "btFileSelectDescSingle": "This torrent contains 1 file. Confirm to start downloading.",
     "btFileSelectDesc": "This torrent contains {count} files. Select which files to download.",
     "btFileSelectAll": "All Files",
+    "btFileTreeView": "Tree view",
+    "btFileListView": "List view",
     "btFileSelectConfirm": "Download {count} file(s) ({size})",
     "btResolvingMagnet": "Resolving magnet link, please wait...",
     "btResolveFailed": "Failed to resolve magnet link: no metadata received (no peers or DHT blocked). The task was marked as error; you can retry it later from the task list.",

--- a/assets/i18n/zh.json
+++ b/assets/i18n/zh.json
@@ -277,6 +277,8 @@
     "btFileSelectDescSingle": "该种子包含 1 个文件，确认后开始下载。",
     "btFileSelectDesc": "该种子包含 {count} 个文件，请选择要下载的文件。",
     "btFileSelectAll": "全部文件",
+    "btFileTreeView": "树形视图",
+    "btFileListView": "列表视图",
     "btFileSelectConfirm": "下载 {count} 个文件（{size}）",
     "btResolvingMagnet": "正在解析磁力链接，请稍候...",
     "btResolveFailed": "磁力链接解析失败：未获取到元数据（无可用 peers 或 DHT 被屏蔽）。任务已标记为错误，可稍后在任务列表重试。",

--- a/lib/src/i18n/translations.dart
+++ b/lib/src/i18n/translations.dart
@@ -417,6 +417,8 @@ class S {
   String btFileSelectDesc(int count) =>
       _r('btFileSelectDesc', {'count': count});
   String get btFileSelectAll => _r('btFileSelectAll');
+  String get btFileTreeView => _r('btFileTreeView');
+  String get btFileListView => _r('btFileListView');
   String btFileSelectConfirm(int count, String size) =>
       _r('btFileSelectConfirm', {'count': count, 'size': size});
   String get btResolvingMagnet => _r('btResolvingMagnet');

--- a/lib/src/mobile/sheets/mobile_bt_file_sheet.dart
+++ b/lib/src/mobile/sheets/mobile_bt_file_sheet.dart
@@ -4,7 +4,7 @@ import 'package:shadcn_ui/shadcn_ui.dart';
 import '../../bindings/bindings.dart';
 import '../../i18n/locale_provider.dart';
 import '../../theme/app_colors.dart';
-import '../../widgets/bt_file_list_widget.dart' show formatBtFileSize;
+import '../../widgets/bt_file_selection_shared.dart' show formatBtFileSize;
 import '../../theme/app_metrics.dart';
 import '../mobile_ui.dart';
 

--- a/lib/src/widgets/bt_file_list_widget.dart
+++ b/lib/src/widgets/bt_file_list_widget.dart
@@ -1,84 +1,11 @@
 import 'package:flutter/widgets.dart';
-import 'package:shadcn_ui/shadcn_ui.dart';
 
 import '../bindings/bindings.dart';
 import '../i18n/locale_provider.dart';
 import '../theme/app_colors.dart';
 import '../theme/app_metrics.dart';
-
-// ---------------------------------------------------------------------------
-// Shared helpers
-// ---------------------------------------------------------------------------
-
-String formatBtFileSize(int bytes) {
-  if (bytes <= 0) return '0 B';
-  if (bytes >= 1024 * 1024 * 1024) {
-    return '${(bytes / (1024 * 1024 * 1024)).toStringAsFixed(2)} GB';
-  }
-  if (bytes >= 1024 * 1024) {
-    return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
-  }
-  if (bytes >= 1024) {
-    return '${(bytes / 1024).toStringAsFixed(1)} KB';
-  }
-  return '$bytes B';
-}
-
-IconData btFileIcon(String path) {
-  final lower = path.toLowerCase();
-  if (lower.endsWith('.mp4') ||
-      lower.endsWith('.mkv') ||
-      lower.endsWith('.avi') ||
-      lower.endsWith('.mov') ||
-      lower.endsWith('.wmv') ||
-      lower.endsWith('.flv') ||
-      lower.endsWith('.webm') ||
-      lower.endsWith('.m4v') ||
-      lower.endsWith('.ts') ||
-      lower.endsWith('.m2ts')) {
-    return LucideIcons.film;
-  }
-  if (lower.endsWith('.mp3') ||
-      lower.endsWith('.flac') ||
-      lower.endsWith('.aac') ||
-      lower.endsWith('.ogg') ||
-      lower.endsWith('.wav') ||
-      lower.endsWith('.m4a') ||
-      lower.endsWith('.opus')) {
-    return LucideIcons.music;
-  }
-  if (lower.endsWith('.jpg') ||
-      lower.endsWith('.jpeg') ||
-      lower.endsWith('.png') ||
-      lower.endsWith('.gif') ||
-      lower.endsWith('.bmp') ||
-      lower.endsWith('.webp') ||
-      lower.endsWith('.svg') ||
-      lower.endsWith('.tiff')) {
-    return LucideIcons.image;
-  }
-  if (lower.endsWith('.zip') ||
-      lower.endsWith('.rar') ||
-      lower.endsWith('.7z') ||
-      lower.endsWith('.tar') ||
-      lower.endsWith('.gz') ||
-      lower.endsWith('.bz2') ||
-      lower.endsWith('.xz')) {
-    return LucideIcons.package2;
-  }
-  if (lower.endsWith('.pdf') ||
-      lower.endsWith('.doc') ||
-      lower.endsWith('.docx') ||
-      lower.endsWith('.xls') ||
-      lower.endsWith('.xlsx') ||
-      lower.endsWith('.ppt') ||
-      lower.endsWith('.pptx') ||
-      lower.endsWith('.txt') ||
-      lower.endsWith('.md')) {
-    return LucideIcons.fileText;
-  }
-  return LucideIcons.file;
-}
+import 'bt_file_selection_shared.dart'
+    show BtCheckbox, BtSelectAllRow, btFileIcon, formatBtFileSize;
 
 // ---------------------------------------------------------------------------
 // BtFileListWidget — the full interactive file selection list.
@@ -125,14 +52,6 @@ class BtFileListWidget extends StatelessWidget {
     return total;
   }
 
-  int get _totalBytes {
-    int total = 0;
-    for (final f in files) {
-      total += f.size.toInt();
-    }
-    return total;
-  }
-
   @override
   Widget build(BuildContext context) {
     final c = AppColors.of(context);
@@ -150,7 +69,6 @@ class BtFileListWidget extends StatelessWidget {
             noneSelected: _noneSelected,
             totalFiles: files.length,
             selectedCount: selectedIndices.length,
-            totalBytes: _totalBytes,
             selectedBytes: _selectedTotalBytes,
             onToggle: onToggleAll,
             c: c,
@@ -177,82 +95,6 @@ class BtFileListWidget extends StatelessWidget {
           ),
         ),
       ],
-    );
-  }
-}
-
-// ---------------------------------------------------------------------------
-// BtSelectAllRow
-// ---------------------------------------------------------------------------
-
-class BtSelectAllRow extends StatelessWidget {
-  final bool allSelected;
-  final bool noneSelected;
-  final int totalFiles;
-  final int selectedCount;
-  final int totalBytes;
-  final int selectedBytes;
-  final VoidCallback onToggle;
-  final AppColors c;
-  final S s;
-
-  const BtSelectAllRow({
-    super.key,
-    required this.allSelected,
-    required this.noneSelected,
-    required this.totalFiles,
-    required this.selectedCount,
-    required this.totalBytes,
-    required this.selectedBytes,
-    required this.onToggle,
-    required this.c,
-    required this.s,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final m = AppMetrics.of(context);
-    return GestureDetector(
-      onTap: onToggle,
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 9),
-        decoration: BoxDecoration(
-          color: allSelected
-              ? m.faint(c.accent)
-              : c.surface1,
-          borderRadius: m.brCard,
-          border: Border.all(
-            color: allSelected
-                ? m.borderFaint(c.accent)
-                : c.border,
-            width: 1,
-          ),
-        ),
-        child: Row(
-          children: [
-            BtCheckbox(
-              checked: allSelected,
-              indeterminate: !allSelected && !noneSelected,
-              accentColor: c.accent,
-            ),
-            const SizedBox(width: 10),
-            Expanded(
-              child: Text(
-                s.btFileSelectAll,
-                style: TextStyle(
-                  fontSize: 13,
-                  fontWeight: FontWeight.w600,
-                  color: c.textPrimary,
-                ),
-              ),
-            ),
-            Text(
-              '$selectedCount / $totalFiles  ·  ${formatBtFileSize(selectedBytes)}',
-              style: TextStyle(fontSize: 11.5, color: c.textMuted),
-            ),
-          ],
-        ),
-      ),
     );
   }
 }
@@ -377,59 +219,6 @@ class BtFileTile extends StatelessWidget {
           ],
         ),
       ),
-    );
-  }
-}
-
-// ---------------------------------------------------------------------------
-// BtCheckbox — minimal checkbox widget (no Material dependency)
-// ---------------------------------------------------------------------------
-
-class BtCheckbox extends StatelessWidget {
-  final bool checked;
-  final bool indeterminate;
-  final Color accentColor;
-
-  const BtCheckbox({
-    super.key,
-    required this.checked,
-    this.indeterminate = false,
-    required this.accentColor,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final m = AppMetrics.of(context);
-    final active = checked || indeterminate;
-    return Container(
-      width: 17,
-      height: 17,
-      decoration: BoxDecoration(
-        borderRadius: m.brSm,
-        color: active ? accentColor : const Color(0x00000000),
-        border: Border.all(
-          color: active ? accentColor : const Color(0x66888888),
-          width: 1.5,
-        ),
-      ),
-      child: active
-          ? Center(
-              child: indeterminate
-                  ? Container(
-                      width: 9,
-                      height: 2,
-                      decoration: BoxDecoration(
-                        color: const Color(0xFFFFFFFF),
-                        borderRadius: m.brProgress,
-                      ),
-                    )
-                  : const Icon(
-                      LucideIcons.check,
-                      size: 11,
-                      color: Color(0xFFFFFFFF),
-                    ),
-            )
-          : null,
     );
   }
 }

--- a/lib/src/widgets/bt_file_selection_dialog.dart
+++ b/lib/src/widgets/bt_file_selection_dialog.dart
@@ -8,7 +8,8 @@ import '../i18n/locale_provider.dart';
 import '../mobile/sheets/mobile_bt_file_sheet.dart';
 import '../theme/app_colors.dart';
 import '../theme/app_metrics.dart';
-import 'bt_file_list_widget.dart';
+import 'bt_file_selection_shared.dart' show formatBtFileSize;
+import 'bt_file_selection_view.dart';
 
 void showBtFileSelectionDialog(
   BuildContext context, {
@@ -179,26 +180,12 @@ class _BtFileSelectionDialogContentState
       ],
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 12),
-        child: BtFileListWidget(
+        child: BtFileSelectionView(
           files: widget.files,
           selectedIndices: _selectedIndices,
-          onToggleAll: () {
+          onSelectionChanged: (selection) {
             setState(() {
-              if (_selectedIndices.length == widget.files.length) {
-                _selectedIndices = {};
-              } else {
-                _selectedIndices =
-                    widget.files.map((f) => f.index.toInt()).toSet();
-              }
-            });
-          },
-          onToggleFile: (idx) {
-            setState(() {
-              if (_selectedIndices.contains(idx)) {
-                _selectedIndices = Set.from(_selectedIndices)..remove(idx);
-              } else {
-                _selectedIndices = Set.from(_selectedIndices)..add(idx);
-              }
+              _selectedIndices = selection;
             });
           },
           maxHeight: 340,

--- a/lib/src/widgets/bt_file_selection_shared.dart
+++ b/lib/src/widgets/bt_file_selection_shared.dart
@@ -1,0 +1,207 @@
+import 'package:flutter/widgets.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+import '../i18n/locale_provider.dart';
+import '../theme/app_colors.dart';
+import '../theme/app_metrics.dart';
+
+String formatBtFileSize(int bytes) {
+  if (bytes <= 0) return '0 B';
+  if (bytes >= 1024 * 1024 * 1024) {
+    return '${(bytes / (1024 * 1024 * 1024)).toStringAsFixed(2)} GB';
+  }
+  if (bytes >= 1024 * 1024) {
+    return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
+  }
+  if (bytes >= 1024) {
+    return '${(bytes / 1024).toStringAsFixed(1)} KB';
+  }
+  return '$bytes B';
+}
+
+IconData btFileIcon(String path) {
+  final lower = path.toLowerCase();
+  if (lower.endsWith('.mp4') ||
+      lower.endsWith('.mkv') ||
+      lower.endsWith('.avi') ||
+      lower.endsWith('.mov') ||
+      lower.endsWith('.wmv') ||
+      lower.endsWith('.flv') ||
+      lower.endsWith('.webm') ||
+      lower.endsWith('.m4v') ||
+      lower.endsWith('.ts') ||
+      lower.endsWith('.m2ts')) {
+    return LucideIcons.film;
+  }
+  if (lower.endsWith('.mp3') ||
+      lower.endsWith('.flac') ||
+      lower.endsWith('.aac') ||
+      lower.endsWith('.ogg') ||
+      lower.endsWith('.wav') ||
+      lower.endsWith('.m4a') ||
+      lower.endsWith('.opus')) {
+    return LucideIcons.music;
+  }
+  if (lower.endsWith('.jpg') ||
+      lower.endsWith('.jpeg') ||
+      lower.endsWith('.png') ||
+      lower.endsWith('.gif') ||
+      lower.endsWith('.bmp') ||
+      lower.endsWith('.webp') ||
+      lower.endsWith('.svg') ||
+      lower.endsWith('.tiff')) {
+    return LucideIcons.image;
+  }
+  if (lower.endsWith('.zip') ||
+      lower.endsWith('.rar') ||
+      lower.endsWith('.7z') ||
+      lower.endsWith('.tar') ||
+      lower.endsWith('.gz') ||
+      lower.endsWith('.bz2') ||
+      lower.endsWith('.xz')) {
+    return LucideIcons.package2;
+  }
+  if (lower.endsWith('.pdf') ||
+      lower.endsWith('.doc') ||
+      lower.endsWith('.docx') ||
+      lower.endsWith('.xls') ||
+      lower.endsWith('.xlsx') ||
+      lower.endsWith('.ppt') ||
+      lower.endsWith('.pptx') ||
+      lower.endsWith('.txt') ||
+      lower.endsWith('.md')) {
+    return LucideIcons.fileText;
+  }
+  return LucideIcons.file;
+}
+
+Set<int> toggleBtFileSelection(
+  Set<int> selectedIndices,
+  Iterable<int> targetIndices,
+) {
+  final indices = targetIndices.toSet();
+  if (indices.isEmpty) return Set<int>.from(selectedIndices);
+
+  final result = Set<int>.from(selectedIndices);
+  if (indices.every(selectedIndices.contains)) {
+    result.removeAll(indices);
+  } else {
+    result.addAll(indices);
+  }
+  return result;
+}
+
+class BtSelectAllRow extends StatelessWidget {
+  final bool allSelected;
+  final bool noneSelected;
+  final int totalFiles;
+  final int selectedCount;
+  final int selectedBytes;
+  final VoidCallback onToggle;
+  final AppColors c;
+  final S s;
+
+  const BtSelectAllRow({
+    super.key,
+    required this.allSelected,
+    required this.noneSelected,
+    required this.totalFiles,
+    required this.selectedCount,
+    required this.selectedBytes,
+    required this.onToggle,
+    required this.c,
+    required this.s,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final m = AppMetrics.of(context);
+    return GestureDetector(
+      onTap: onToggle,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 9),
+        decoration: BoxDecoration(
+          color: allSelected ? m.faint(c.accent) : c.surface1,
+          borderRadius: m.brCard,
+          border: Border.all(
+            color: allSelected ? m.borderFaint(c.accent) : c.border,
+            width: 1,
+          ),
+        ),
+        child: Row(
+          children: [
+            BtCheckbox(
+              checked: allSelected,
+              indeterminate: !allSelected && !noneSelected,
+              accentColor: c.accent,
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Text(
+                s.btFileSelectAll,
+                style: TextStyle(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600,
+                  color: c.textPrimary,
+                ),
+              ),
+            ),
+            Text(
+              '$selectedCount / $totalFiles  ·  ${formatBtFileSize(selectedBytes)}',
+              style: TextStyle(fontSize: 11.5, color: c.textMuted),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class BtCheckbox extends StatelessWidget {
+  final bool checked;
+  final bool indeterminate;
+  final Color accentColor;
+
+  const BtCheckbox({
+    super.key,
+    required this.checked,
+    this.indeterminate = false,
+    required this.accentColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final m = AppMetrics.of(context);
+    final active = checked || indeterminate;
+    return Container(
+      width: 17,
+      height: 17,
+      decoration: BoxDecoration(
+        borderRadius: m.brSm,
+        color: active ? accentColor : const Color(0x00000000),
+        border: Border.all(
+          color: active ? accentColor : const Color(0x66888888),
+          width: 1.5,
+        ),
+      ),
+      child: active
+          ? Center(
+              child: indeterminate
+                  ? Container(
+                      width: 9,
+                      height: 2,
+                      decoration: BoxDecoration(
+                        color: const Color(0xFFFFFFFF),
+                        borderRadius: m.brProgress,
+                      ),
+                    )
+                  : const Icon(
+                      LucideIcons.check,
+                      size: 11,
+                      color: Color(0xFFFFFFFF),
+                    ),
+            )
+          : null,
+    );
+  }
+}

--- a/lib/src/widgets/bt_file_selection_view.dart
+++ b/lib/src/widgets/bt_file_selection_view.dart
@@ -1,0 +1,175 @@
+import 'package:flutter/widgets.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+import '../bindings/bindings.dart';
+import '../i18n/locale_provider.dart';
+import '../theme/app_colors.dart';
+import '../theme/app_metrics.dart';
+import 'bt_file_list_widget.dart';
+import 'bt_file_selection_shared.dart' show toggleBtFileSelection;
+import 'bt_file_tree_widget.dart';
+
+enum BtFileDisplayMode { tree, list }
+
+class BtFileSelectionView extends StatefulWidget {
+  final List<BtFileEntry> files;
+  final Set<int> selectedIndices;
+  final ValueChanged<Set<int>> onSelectionChanged;
+  final double maxHeight;
+
+  const BtFileSelectionView({
+    super.key,
+    required this.files,
+    required this.selectedIndices,
+    required this.onSelectionChanged,
+    this.maxHeight = 300,
+  });
+
+  @override
+  State<BtFileSelectionView> createState() => _BtFileSelectionViewState();
+}
+
+class _BtFileSelectionViewState extends State<BtFileSelectionView> {
+  BtFileDisplayMode _mode = BtFileDisplayMode.tree;
+
+  void _toggleIndices(Iterable<int> indices) {
+    widget.onSelectionChanged(
+      toggleBtFileSelection(widget.selectedIndices, indices),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final c = AppColors.of(context);
+    final s = LocaleScope.of(context);
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (widget.files.length > 1) ...[
+          Align(
+            alignment: Alignment.centerRight,
+            child: _BtFileDisplayModeControl(
+              mode: _mode,
+              onChanged: (mode) => setState(() => _mode = mode),
+              c: c,
+              s: s,
+            ),
+          ),
+          const SizedBox(height: 6),
+        ],
+        if (_mode == BtFileDisplayMode.tree)
+          BtFileTreeWidget(
+            files: widget.files,
+            selectedIndices: widget.selectedIndices,
+            onSelectionChanged: widget.onSelectionChanged,
+            maxHeight: widget.maxHeight,
+          )
+        else
+          BtFileListWidget(
+            files: widget.files,
+            selectedIndices: widget.selectedIndices,
+            onToggleAll: () =>
+                _toggleIndices(widget.files.map((file) => file.index.toInt())),
+            onToggleFile: (index) => _toggleIndices([index]),
+            maxHeight: widget.maxHeight,
+          ),
+      ],
+    );
+  }
+}
+
+class _BtFileDisplayModeControl extends StatelessWidget {
+  final BtFileDisplayMode mode;
+  final ValueChanged<BtFileDisplayMode> onChanged;
+  final AppColors c;
+  final S s;
+
+  const _BtFileDisplayModeControl({
+    required this.mode,
+    required this.onChanged,
+    required this.c,
+    required this.s,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final m = AppMetrics.of(context);
+    return Container(
+      padding: const EdgeInsets.all(3),
+      decoration: BoxDecoration(
+        color: c.surface1,
+        borderRadius: m.brCard,
+        border: Border.all(color: c.border),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _BtFileDisplayModeButton(
+            key: const ValueKey('bt-view-tree'),
+            icon: LucideIcons.folderTree,
+            tooltip: s.btFileTreeView,
+            selected: mode == BtFileDisplayMode.tree,
+            onTap: () => onChanged(BtFileDisplayMode.tree),
+            c: c,
+          ),
+          _BtFileDisplayModeButton(
+            key: const ValueKey('bt-view-list'),
+            icon: LucideIcons.list,
+            tooltip: s.btFileListView,
+            selected: mode == BtFileDisplayMode.list,
+            onTap: () => onChanged(BtFileDisplayMode.list),
+            c: c,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _BtFileDisplayModeButton extends StatelessWidget {
+  final IconData icon;
+  final String tooltip;
+  final bool selected;
+  final VoidCallback onTap;
+  final AppColors c;
+
+  const _BtFileDisplayModeButton({
+    super.key,
+    required this.icon,
+    required this.tooltip,
+    required this.selected,
+    required this.onTap,
+    required this.c,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final m = AppMetrics.of(context);
+    return ShadTooltip(
+      waitDuration: const Duration(milliseconds: 350),
+      builder: (_) => Text(tooltip),
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: onTap,
+          child: Container(
+            width: 30,
+            height: 30,
+            decoration: BoxDecoration(
+              color: selected ? m.soft(c.accent) : const Color(0x00000000),
+              borderRadius: m.brMd,
+            ),
+            child: Icon(
+              icon,
+              size: 15,
+              color: selected ? c.accent : c.textMuted,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/widgets/bt_file_selection_view.dart
+++ b/lib/src/widgets/bt_file_selection_view.dart
@@ -32,6 +32,10 @@ class BtFileSelectionView extends StatefulWidget {
 class _BtFileSelectionViewState extends State<BtFileSelectionView> {
   BtFileDisplayMode _mode = BtFileDisplayMode.tree;
 
+  /// Directory expansion is owned here (not inside the tree widget) so it
+  /// survives switching between tree and list views.
+  final Set<String> _collapsedDirectories = {};
+
   void _toggleIndices(Iterable<int> indices) {
     widget.onSelectionChanged(
       toggleBtFileSelection(widget.selectedIndices, indices),
@@ -65,6 +69,12 @@ class _BtFileSelectionViewState extends State<BtFileSelectionView> {
             selectedIndices: widget.selectedIndices,
             onSelectionChanged: widget.onSelectionChanged,
             maxHeight: widget.maxHeight,
+            collapsedDirectories: _collapsedDirectories,
+            onToggleDirectory: (path) => setState(() {
+              if (!_collapsedDirectories.remove(path)) {
+                _collapsedDirectories.add(path);
+              }
+            }),
           )
         else
           BtFileListWidget(

--- a/lib/src/widgets/bt_file_tree_widget.dart
+++ b/lib/src/widgets/bt_file_tree_widget.dart
@@ -1,0 +1,479 @@
+import 'package:flutter/widgets.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+import '../bindings/bindings.dart';
+import '../i18n/locale_provider.dart';
+import '../theme/app_colors.dart';
+import '../theme/app_metrics.dart';
+import 'bt_file_selection_shared.dart'
+    show
+        BtCheckbox,
+        BtSelectAllRow,
+        btFileIcon,
+        formatBtFileSize,
+        toggleBtFileSelection;
+
+class BtFileTreeNode {
+  final String name;
+  final String path;
+  final BtFileEntry? file;
+  final List<BtFileTreeNode> children;
+  final List<BtFileEntry> descendantFiles;
+
+  const BtFileTreeNode._({
+    required this.name,
+    required this.path,
+    required this.file,
+    required this.children,
+    required this.descendantFiles,
+  });
+
+  bool get isDirectory => file == null;
+}
+
+class _MutableBtDirectory {
+  final String name;
+  final String path;
+  final Map<String, _MutableBtDirectory> directories = {};
+  final List<BtFileTreeNode> files = [];
+
+  _MutableBtDirectory({required this.name, required this.path});
+}
+
+List<BtFileTreeNode> buildBtFileTree(List<BtFileEntry> files) {
+  final root = _MutableBtDirectory(name: '', path: '');
+
+  for (final file in files) {
+    final parts = file.path
+        .split(RegExp(r'[\\/]+'))
+        .where((part) => part.isNotEmpty)
+        .toList();
+    if (parts.isEmpty) parts.add('file_${file.index}');
+
+    var parent = root;
+    for (var i = 0; i < parts.length - 1; i++) {
+      final name = parts[i];
+      final path = parent.path.isEmpty ? name : '${parent.path}/$name';
+      parent = parent.directories.putIfAbsent(
+        name,
+        () => _MutableBtDirectory(name: name, path: path),
+      );
+    }
+
+    final name = parts.last;
+    final path = parent.path.isEmpty ? name : '${parent.path}/$name';
+    parent.files.add(
+      BtFileTreeNode._(
+        name: name,
+        path: path,
+        file: file,
+        children: const [],
+        descendantFiles: [file],
+      ),
+    );
+  }
+
+  BtFileTreeNode freezeDirectory(_MutableBtDirectory directory) {
+    final children =
+        <BtFileTreeNode>[
+          for (final child in directory.directories.values)
+            freezeDirectory(child),
+          ...directory.files,
+        ]..sort((a, b) {
+          if (a.isDirectory != b.isDirectory) return a.isDirectory ? -1 : 1;
+          final byName = a.name.toLowerCase().compareTo(b.name.toLowerCase());
+          if (byName != 0) return byName;
+          return a.path.compareTo(b.path);
+        });
+    return BtFileTreeNode._(
+      name: directory.name,
+      path: directory.path,
+      file: null,
+      children: children,
+      descendantFiles: [for (final child in children) ...child.descendantFiles],
+    );
+  }
+
+  return freezeDirectory(root).children;
+}
+
+class BtFileTreeWidget extends StatefulWidget {
+  final List<BtFileEntry> files;
+  final Set<int> selectedIndices;
+  final ValueChanged<Set<int>> onSelectionChanged;
+  final double maxHeight;
+
+  const BtFileTreeWidget({
+    super.key,
+    required this.files,
+    required this.selectedIndices,
+    required this.onSelectionChanged,
+    this.maxHeight = 300,
+  });
+
+  @override
+  State<BtFileTreeWidget> createState() => _BtFileTreeWidgetState();
+}
+
+class _BtFileTreeWidgetState extends State<BtFileTreeWidget> {
+  late List<BtFileTreeNode> _roots;
+  final Set<String> _expandedDirectories = {};
+  Set<String> _knownDirectories = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _rebuildTree();
+  }
+
+  @override
+  void didUpdateWidget(covariant BtFileTreeWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!identical(oldWidget.files, widget.files)) {
+      _rebuildTree();
+    }
+  }
+
+  void _rebuildTree() {
+    _roots = buildBtFileTree(widget.files);
+    final directories = <String>{};
+
+    void collectDirectories(List<BtFileTreeNode> nodes) {
+      for (final node in nodes) {
+        if (!node.isDirectory) continue;
+        directories.add(node.path);
+        collectDirectories(node.children);
+      }
+    }
+
+    collectDirectories(_roots);
+    _expandedDirectories.retainAll(directories);
+    _expandedDirectories.addAll(directories.difference(_knownDirectories));
+    _knownDirectories = directories;
+  }
+
+  bool get _allSelected => widget.files.every(
+    (file) => widget.selectedIndices.contains(file.index.toInt()),
+  );
+
+  int get _selectedTotalBytes => widget.files
+      .where((file) => widget.selectedIndices.contains(file.index.toInt()))
+      .fold(0, (total, file) => total + file.size.toInt());
+
+  void _toggleFiles(Iterable<BtFileEntry> targetFiles) {
+    widget.onSelectionChanged(
+      toggleBtFileSelection(
+        widget.selectedIndices,
+        targetFiles.map((file) => file.index.toInt()),
+      ),
+    );
+  }
+
+  void _toggleExpanded(String path) {
+    setState(() {
+      if (!_expandedDirectories.remove(path)) {
+        _expandedDirectories.add(path);
+      }
+    });
+  }
+
+  List<Widget> _buildTreeRows(
+    List<BtFileTreeNode> nodes,
+    int depth,
+    AppColors c,
+  ) {
+    final rows = <Widget>[];
+    for (final node in nodes) {
+      if (node.isDirectory) {
+        final expanded = _expandedDirectories.contains(node.path);
+        rows.add(
+          BtDirectoryTile(
+            key: ValueKey('bt-tree-dir:${node.path}'),
+            node: node,
+            depth: depth,
+            isExpanded: expanded,
+            selectedIndices: widget.selectedIndices,
+            onToggleExpanded: () => _toggleExpanded(node.path),
+            onToggleSelection: () => _toggleFiles(node.descendantFiles),
+            c: c,
+          ),
+        );
+        if (expanded) {
+          rows.addAll(_buildTreeRows(node.children, depth + 1, c));
+        }
+      } else {
+        final file = node.file!;
+        rows.add(
+          _BtTreeFileTile(
+            key: ValueKey('bt-tree-file:${file.index}'),
+            file: file,
+            depth: depth,
+            isSelected: widget.selectedIndices.contains(file.index.toInt()),
+            onTap: () => _toggleFiles([file]),
+            c: c,
+          ),
+        );
+      }
+    }
+    return rows;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final c = AppColors.of(context);
+    final s = LocaleScope.of(context);
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (widget.files.length > 1) ...[
+          BtSelectAllRow(
+            allSelected: _allSelected,
+            noneSelected: widget.selectedIndices.isEmpty,
+            totalFiles: widget.files.length,
+            selectedCount: widget.selectedIndices.length,
+            selectedBytes: _selectedTotalBytes,
+            onToggle: () => _toggleFiles(widget.files),
+            c: c,
+            s: s,
+          ),
+          const SizedBox(height: 8),
+        ],
+        ConstrainedBox(
+          constraints: BoxConstraints(maxHeight: widget.maxHeight),
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [..._buildTreeRows(_roots, 0, c)],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class BtDirectoryTile extends StatelessWidget {
+  final BtFileTreeNode node;
+  final int depth;
+  final bool isExpanded;
+  final Set<int> selectedIndices;
+  final VoidCallback onToggleExpanded;
+  final VoidCallback onToggleSelection;
+  final AppColors c;
+
+  const BtDirectoryTile({
+    super.key,
+    required this.node,
+    required this.depth,
+    required this.isExpanded,
+    required this.selectedIndices,
+    required this.onToggleExpanded,
+    required this.onToggleSelection,
+    required this.c,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final m = AppMetrics.of(context);
+    var selectedCount = 0;
+    var selectedBytes = 0;
+    for (final file in node.descendantFiles) {
+      if (selectedIndices.contains(file.index.toInt())) {
+        selectedCount++;
+        selectedBytes += file.size.toInt();
+      }
+    }
+    final allSelected = selectedCount == node.descendantFiles.length;
+    final noneSelected = selectedCount == 0;
+    final active = !noneSelected;
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 4),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 7),
+      decoration: BoxDecoration(
+        color: active ? m.faint(c.accent) : c.surface1,
+        borderRadius: m.brCard,
+        border: Border.all(
+          color: active ? m.borderFaint(c.accent) : c.border,
+          width: 1,
+        ),
+      ),
+      child: Row(
+        children: [
+          SizedBox(width: _btTreeIndent(depth)),
+          GestureDetector(
+            key: ValueKey('bt-tree-expand:${node.path}'),
+            behavior: HitTestBehavior.opaque,
+            onTap: onToggleExpanded,
+            child: SizedBox(
+              width: 24,
+              height: 30,
+              child: Icon(
+                isExpanded ? LucideIcons.chevronDown : LucideIcons.chevronRight,
+                size: 14,
+                color: c.textMuted,
+              ),
+            ),
+          ),
+          GestureDetector(
+            key: ValueKey('bt-tree-select:${node.path}'),
+            behavior: HitTestBehavior.opaque,
+            onTap: onToggleSelection,
+            child: SizedBox(
+              width: 18,
+              height: 30,
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: BtCheckbox(
+                  checked: allSelected,
+                  indeterminate: !allSelected && !noneSelected,
+                  accentColor: c.accent,
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: GestureDetector(
+              key: ValueKey('bt-tree-open:${node.path}'),
+              behavior: HitTestBehavior.opaque,
+              onTap: onToggleExpanded,
+              child: Row(
+                children: [
+                  Container(
+                    width: 28,
+                    height: 28,
+                    decoration: BoxDecoration(
+                      color: active ? m.soft(c.accent) : c.surface2,
+                      borderRadius: m.brMd,
+                    ),
+                    child: Icon(
+                      isExpanded ? LucideIcons.folderOpen : LucideIcons.folder,
+                      size: 14,
+                      color: active ? c.accent : c.textMuted,
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: Text(
+                      node.name,
+                      style: TextStyle(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w600,
+                        color: c.textPrimary,
+                      ),
+                      overflow: TextOverflow.ellipsis,
+                      maxLines: 1,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    '$selectedCount/${node.descendantFiles.length}  ·  '
+                    '${formatBtFileSize(selectedBytes)}',
+                    style: TextStyle(
+                      fontSize: 11.5,
+                      color: c.textMuted,
+                      fontFeatures: const [FontFeature.tabularFigures()],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _BtTreeFileTile extends StatelessWidget {
+  final BtFileEntry file;
+  final int depth;
+  final bool isSelected;
+  final VoidCallback onTap;
+  final AppColors c;
+
+  const _BtTreeFileTile({
+    super.key,
+    required this.file,
+    required this.depth,
+    required this.isSelected,
+    required this.onTap,
+    required this.c,
+  });
+
+  String get _fileName {
+    final parts = file.path
+        .split(RegExp(r'[\\/]+'))
+        .where((part) => part.isNotEmpty)
+        .toList();
+    return parts.isEmpty ? file.path : parts.last;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final m = AppMetrics.of(context);
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        margin: const EdgeInsets.only(bottom: 4),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 9),
+        decoration: BoxDecoration(
+          color: isSelected ? m.faint(c.accent) : c.surface1,
+          borderRadius: m.brCard,
+          border: Border.all(
+            color: isSelected ? m.borderFaint(c.accent) : c.border,
+            width: 1,
+          ),
+        ),
+        child: Row(
+          children: [
+            SizedBox(width: _btTreeIndent(depth)),
+            const SizedBox(width: 24),
+            BtCheckbox(checked: isSelected, accentColor: c.accent),
+            const SizedBox(width: 10),
+            Container(
+              width: 28,
+              height: 28,
+              decoration: BoxDecoration(
+                color: isSelected ? m.soft(c.accent) : c.surface2,
+                borderRadius: m.brMd,
+              ),
+              child: Icon(
+                btFileIcon(file.path),
+                size: 14,
+                color: isSelected ? c.accent : c.textMuted,
+              ),
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Text(
+                _fileName,
+                style: TextStyle(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w500,
+                  color: c.textPrimary,
+                ),
+                overflow: TextOverflow.ellipsis,
+                maxLines: 1,
+              ),
+            ),
+            const SizedBox(width: 8),
+            Text(
+              formatBtFileSize(file.size.toInt()),
+              style: TextStyle(
+                fontSize: 11.5,
+                color: c.textMuted,
+                fontFeatures: const [FontFeature.tabularFigures()],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+double _btTreeIndent(int depth) => (depth > 8 ? 8 : depth) * 18.0;

--- a/lib/src/widgets/bt_file_tree_widget.dart
+++ b/lib/src/widgets/bt_file_tree_widget.dart
@@ -103,12 +103,21 @@ class BtFileTreeWidget extends StatefulWidget {
   final ValueChanged<Set<int>> onSelectionChanged;
   final double maxHeight;
 
+  /// Collapsed directory paths. When supplied together with
+  /// [onToggleDirectory] the expansion state is controlled by the parent,
+  /// so it survives tree/list view switches. When null the widget keeps its
+  /// own internal expansion state (all directories expanded by default).
+  final Set<String>? collapsedDirectories;
+  final ValueChanged<String>? onToggleDirectory;
+
   const BtFileTreeWidget({
     super.key,
     required this.files,
     required this.selectedIndices,
     required this.onSelectionChanged,
     this.maxHeight = 300,
+    this.collapsedDirectories,
+    this.onToggleDirectory,
   });
 
   @override
@@ -117,8 +126,14 @@ class BtFileTreeWidget extends StatefulWidget {
 
 class _BtFileTreeWidgetState extends State<BtFileTreeWidget> {
   late List<BtFileTreeNode> _roots;
-  final Set<String> _expandedDirectories = {};
-  Set<String> _knownDirectories = {};
+
+  /// Fallback expansion state used only when the parent does not control it.
+  /// A directory is expanded unless its path is present here (expand-all
+  /// default); stale paths for removed directories are harmless.
+  final Set<String> _internalCollapsed = {};
+
+  Set<String> get _collapsed =>
+      widget.collapsedDirectories ?? _internalCollapsed;
 
   @override
   void initState() {
@@ -136,20 +151,6 @@ class _BtFileTreeWidgetState extends State<BtFileTreeWidget> {
 
   void _rebuildTree() {
     _roots = buildBtFileTree(widget.files);
-    final directories = <String>{};
-
-    void collectDirectories(List<BtFileTreeNode> nodes) {
-      for (final node in nodes) {
-        if (!node.isDirectory) continue;
-        directories.add(node.path);
-        collectDirectories(node.children);
-      }
-    }
-
-    collectDirectories(_roots);
-    _expandedDirectories.retainAll(directories);
-    _expandedDirectories.addAll(directories.difference(_knownDirectories));
-    _knownDirectories = directories;
   }
 
   bool get _allSelected => widget.files.every(
@@ -169,10 +170,17 @@ class _BtFileTreeWidgetState extends State<BtFileTreeWidget> {
     );
   }
 
+  bool _isExpanded(String path) => !_collapsed.contains(path);
+
   void _toggleExpanded(String path) {
+    final onToggle = widget.onToggleDirectory;
+    if (onToggle != null) {
+      onToggle(path);
+      return;
+    }
     setState(() {
-      if (!_expandedDirectories.remove(path)) {
-        _expandedDirectories.add(path);
+      if (!_internalCollapsed.remove(path)) {
+        _internalCollapsed.add(path);
       }
     });
   }
@@ -185,7 +193,7 @@ class _BtFileTreeWidgetState extends State<BtFileTreeWidget> {
     final rows = <Widget>[];
     for (final node in nodes) {
       if (node.isDirectory) {
-        final expanded = _expandedDirectories.contains(node.path);
+        final expanded = _isExpanded(node.path);
         rows.add(
           BtDirectoryTile(
             key: ValueKey('bt-tree-dir:${node.path}'),
@@ -206,6 +214,7 @@ class _BtFileTreeWidgetState extends State<BtFileTreeWidget> {
         rows.add(
           _BtTreeFileTile(
             key: ValueKey('bt-tree-file:${file.index}'),
+            name: node.name,
             file: file,
             depth: depth,
             isSelected: widget.selectedIndices.contains(file.index.toInt()),
@@ -389,6 +398,7 @@ class BtDirectoryTile extends StatelessWidget {
 }
 
 class _BtTreeFileTile extends StatelessWidget {
+  final String name;
   final BtFileEntry file;
   final int depth;
   final bool isSelected;
@@ -397,20 +407,13 @@ class _BtTreeFileTile extends StatelessWidget {
 
   const _BtTreeFileTile({
     super.key,
+    required this.name,
     required this.file,
     required this.depth,
     required this.isSelected,
     required this.onTap,
     required this.c,
   });
-
-  String get _fileName {
-    final parts = file.path
-        .split(RegExp(r'[\\/]+'))
-        .where((part) => part.isNotEmpty)
-        .toList();
-    return parts.isEmpty ? file.path : parts.last;
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -450,7 +453,7 @@ class _BtTreeFileTile extends StatelessWidget {
             const SizedBox(width: 10),
             Expanded(
               child: Text(
-                _fileName,
+                name,
                 style: TextStyle(
                   fontSize: 13,
                   fontWeight: FontWeight.w500,

--- a/lib/src/widgets/manifest_browse_list.dart
+++ b/lib/src/widgets/manifest_browse_list.dart
@@ -14,7 +14,7 @@ import '../models/download_task.dart';
 import '../models/manifest_selection.dart';
 import '../theme/app_colors.dart';
 import '../theme/app_metrics.dart';
-import 'bt_file_list_widget.dart' show BtCheckbox;
+import 'bt_file_selection_shared.dart' show BtCheckbox;
 
 /// 行高恒 34px（design §4.10：1000+ 项虚拟化后 DOM 仅 ~25 行）。
 const double kManifestRowHeight = 34;

--- a/lib/src/widgets/new_download_dialog.dart
+++ b/lib/src/widgets/new_download_dialog.dart
@@ -36,7 +36,8 @@ import '../services/resolve_preview_client.dart';
 import '../services/cloud/cloud_auth_service.dart';
 import '../services/cloud/cloud_client.dart';
 
-import 'bt_file_list_widget.dart';
+import 'bt_file_selection_shared.dart' show formatBtFileSize;
+import 'bt_file_selection_view.dart';
 import 'dir_picker_field.dart';
 import 'manifest_select_dialog.dart';
 import 'thread_selector.dart';
@@ -150,9 +151,9 @@ class _NewDownloadDialogContentState extends State<_NewDownloadDialogContent> {
   /// TorrentMetaResult 信号订阅
   StreamSubscription<RustSignalPack<TorrentMetaResult>>? _metaSub;
 
-  // ── 磁力链接等待文件列表状态机 ─────────────────────────────────────────────
+  // ── 磁力链接等待文件选择状态机 ─────────────────────────────────────────────
   // 状态：null = 普通模式；'probing' = 已创建任务正在等待 DHT 解析；
-  //        'selecting' = 文件列表已到达，等待用户选择；
+  //        'selecting' = 文件元数据已到达，展示文件选择视图；
   //        'error' = 解析失败（任务已转 error，如元数据解析超时）
   String? _btWaitPhase; // null | 'probing' | 'selecting' | 'error'
 
@@ -168,7 +169,7 @@ class _NewDownloadDialogContentState extends State<_NewDownloadDialogContent> {
   /// TaskProgress 信号订阅 — 监听磁力任务在等待阶段转入 error 状态（#379）
   StreamSubscription<RustSignalPack<TaskProgress>>? _btProgressSub;
 
-  /// 收到的 BT 文件列表（Phase=selecting 时非空）
+  /// 收到的 BT 文件条目（Phase=selecting 时非空）
   List<BtFileEntry> _btFiles = [];
 
   /// 用户在对话框内对 BT 文件的勾选状态
@@ -267,10 +268,10 @@ class _NewDownloadDialogContentState extends State<_NewDownloadDialogContent> {
     });
   }
 
-  /// 由 [BtFileSelectionService] 回调：DHT 解析完成，文件列表已就绪。
+  /// 由 [BtFileSelectionService] 回调：DHT 解析完成，文件元数据已就绪。
   void _onBtFilesInfoReceived(BtFilesInfo msg) {
     // 用户已取消（probing 阶段点取消、或对话框被关闭）：
-    // 立刻发 [-1] 让 Rust 将任务暂停，不展示文件列表。
+    // 立刻发 [-1] 让 Rust 将任务暂停，不展示文件选择视图。
     if (_btCancelPending || !mounted || _btWaitPhase != 'probing') {
       SelectBtFiles(
         taskId: msg.taskId,
@@ -764,30 +765,15 @@ class _NewDownloadDialogContentState extends State<_NewDownloadDialogContent> {
               ],
             ),
           )
-        // ── File list (parsed successfully) ───────────────────────────────
+        // File selection view (tree by default, list optional).
         else if (meta != null && selection != null)
-          BtFileListWidget(
+          BtFileSelectionView(
+            key: ValueKey('torrent-file-selection:$path'),
             files: meta.files,
             selectedIndices: selection,
-            onToggleAll: () {
+            onSelectionChanged: (updatedSelection) {
               setState(() {
-                if (selection.length == meta.files.length) {
-                  _torrentSelections[path] = {};
-                } else {
-                  _torrentSelections[path] = meta.files
-                      .map((f) => f.index.toInt())
-                      .toSet();
-                }
-              });
-            },
-            onToggleFile: (idx) {
-              setState(() {
-                final current = _torrentSelections[path] ?? {};
-                if (current.contains(idx)) {
-                  _torrentSelections[path] = Set.from(current)..remove(idx);
-                } else {
-                  _torrentSelections[path] = Set.from(current)..add(idx);
-                }
+                _torrentSelections[path] = updatedSelection;
               });
             },
             maxHeight: 260,
@@ -1029,7 +1015,8 @@ class _NewDownloadDialogContentState extends State<_NewDownloadDialogContent> {
     }
 
     // 单条磁力链接（立即下载）：对话框保持打开，转入 loading 阶段等待
-    // 文件列表；稍后下载则跳过此分支直接建暂停任务——文件选择推迟到
+    // 文件元数据并进入选择视图；稍后下载则跳过此分支直接建暂停任务，
+    // 文件选择推迟到
     // 任务真正启动时（引擎经 HostSelection 弹选择框）。
     if (entries.length == 1 &&
         !later &&
@@ -1339,11 +1326,11 @@ class _NewDownloadDialogContentState extends State<_NewDownloadDialogContent> {
               mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                // ── BT 等待文件列表阶段 ──────────────────────────────────────────
+                // ── BT 等待文件选择阶段 ──────────────────────────────────────────
                 if (_btWaitPhase != null) ...[
                   _buildBtWaitBody(s, c),
                 ] else if (_hasTorrentFiles) ...[
-                  // ── Per-torrent header + file list ────────────────────────────
+                  // Per-torrent header and selectable file view.
                   for (int ti = 0; ti < _torrentFilePaths.length; ti++)
                     _buildTorrentFileEntry(ti, c, s),
                   const SizedBox(height: 8),
@@ -2062,26 +2049,13 @@ class _NewDownloadDialogContentState extends State<_NewDownloadDialogContent> {
         ),
       );
     }
-    // selecting 阶段：文件列表
-    return BtFileListWidget(
+    // selecting 阶段：文件选择视图（默认树形，可切换列表）
+    return BtFileSelectionView(
       files: _btFiles,
       selectedIndices: _btSelectedIndices,
-      onToggleAll: () {
+      onSelectionChanged: (selection) {
         setState(() {
-          if (_btSelectedIndices.length == _btFiles.length) {
-            _btSelectedIndices = {};
-          } else {
-            _btSelectedIndices = _btFiles.map((f) => f.index.toInt()).toSet();
-          }
-        });
-      },
-      onToggleFile: (idx) {
-        setState(() {
-          if (_btSelectedIndices.contains(idx)) {
-            _btSelectedIndices = Set.from(_btSelectedIndices)..remove(idx);
-          } else {
-            _btSelectedIndices = Set.from(_btSelectedIndices)..add(idx);
-          }
+          _btSelectedIndices = selection;
         });
       },
       maxHeight: 340,

--- a/test/bt_file_tree_widget_test.dart
+++ b/test/bt_file_tree_widget_test.dart
@@ -1,0 +1,193 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flux_down/src/bindings/bindings.dart';
+import 'package:flux_down/src/i18n/locale_provider.dart';
+import 'package:flux_down/src/theme/app_theme.dart';
+import 'package:flux_down/src/theme/flux_theme_tokens.dart';
+import 'package:flux_down/src/widgets/bt_file_list_widget.dart';
+import 'package:flux_down/src/widgets/bt_file_selection_shared.dart'
+    show BtCheckbox, toggleBtFileSelection;
+import 'package:flux_down/src/widgets/bt_file_selection_view.dart';
+import 'package:flux_down/src/widgets/bt_file_tree_widget.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+const _files = [
+  BtFileEntry(index: 0, path: 'Example/Season 1/Episode 1.mkv', size: 100),
+  BtFileEntry(index: 1, path: r'Example\Season 1\Episode 2.mkv', size: 200),
+  BtFileEntry(index: 2, path: 'Example/Season 2/Episode 3.mkv', size: 300),
+  BtFileEntry(index: 3, path: 'Example/readme.txt', size: 20),
+];
+
+Widget _wrap(Widget child) {
+  final tokens = FluxThemeTokens.defaultDark();
+  final theme = buildThemeFromTokens(tokens);
+  return FluxThemeScope(
+    tokens: tokens,
+    child: ShadTheme(
+      data: theme,
+      child: LocaleScope(
+        s: S.of('zh'),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: DefaultTextStyle(
+            style: theme.textTheme.p.copyWith(
+              color: theme.colorScheme.foreground,
+            ),
+            child: WidgetsApp(
+              color: theme.colorScheme.primary,
+              debugShowCheckedModeBanner: false,
+              home: Center(child: SizedBox(width: 560, child: child)),
+              pageRouteBuilder: <T>(RouteSettings settings, WidgetBuilder b) {
+                return PageRouteBuilder<T>(
+                  settings: settings,
+                  pageBuilder: (context, _, _) => b(context),
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUpAll(I18nStore.load);
+
+  test('buildBtFileTree preserves nested hierarchy for both separators', () {
+    final roots = buildBtFileTree(_files);
+    final example = roots.singleWhere((node) => node.name == 'Example');
+    final season1 = example.children.singleWhere(
+      (node) => node.name == 'Season 1',
+    );
+
+    expect(example.isDirectory, isTrue);
+    expect(example.descendantFiles.map((file) => file.index), {0, 1, 2, 3});
+    expect(season1.descendantFiles.map((file) => file.index), {0, 1});
+    expect(season1.children.map((node) => node.name), [
+      'Episode 1.mkv',
+      'Episode 2.mkv',
+    ]);
+  });
+
+  test('toggleBtFileSelection toggles a whole branch atomically', () {
+    expect(toggleBtFileSelection({0, 1, 2, 3}, [0, 1]), {2, 3});
+    expect(toggleBtFileSelection({2, 3}, [0, 1]), {0, 1, 2, 3});
+    expect(toggleBtFileSelection({0, 2, 3}, [0, 1]), {0, 1, 2, 3});
+  });
+
+  testWidgets('directory rows cascade selection and expose partial state', (
+    tester,
+  ) async {
+    var selected = <int>{0, 1, 2, 3};
+
+    await tester.pumpWidget(
+      _wrap(
+        StatefulBuilder(
+          builder: (context, setState) => BtFileSelectionView(
+            files: _files,
+            selectedIndices: selected,
+            onSelectionChanged: (value) {
+              setState(() => selected = value);
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Episode 1.mkv'), findsOneWidget);
+    await tester.tap(
+      find.byKey(const ValueKey('bt-tree-select:Example/Season 1')),
+    );
+    await tester.pump();
+
+    expect(selected, {2, 3});
+    final rootCheckbox = tester.widget<BtCheckbox>(
+      find.descendant(
+        of: find.byKey(const ValueKey('bt-tree-dir:Example')),
+        matching: find.byType(BtCheckbox),
+      ),
+    );
+    expect(rootCheckbox.checked, isFalse);
+    expect(rootCheckbox.indeterminate, isTrue);
+
+    await tester.tap(
+      find.byKey(const ValueKey('bt-tree-expand:Example/Season 1')),
+    );
+    await tester.pump();
+    expect(find.text('Episode 1.mkv'), findsNothing);
+    expect(selected, {2, 3});
+
+    await tester.tap(
+      find.byKey(const ValueKey('bt-tree-open:Example/Season 1')),
+    );
+    await tester.pump();
+    expect(find.text('Episode 1.mkv'), findsOneWidget);
+
+    await tester.tap(
+      find.byKey(const ValueKey('bt-tree-select:Example/Season 1')),
+    );
+    await tester.pump();
+    expect(selected, {0, 1, 2, 3});
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('same-level directory and file checkboxes are aligned', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrap(
+        BtFileTreeWidget(
+          files: _files,
+          selectedIndices: const {0, 1, 2, 3},
+          onSelectionChanged: (_) {},
+        ),
+      ),
+    );
+
+    final directoryCheckbox = find.descendant(
+      of: find.byKey(const ValueKey('bt-tree-dir:Example/Season 1')),
+      matching: find.byType(BtCheckbox),
+    );
+    final fileCheckbox = find.descendant(
+      of: find.byKey(const ValueKey('bt-tree-file:3')),
+      matching: find.byType(BtCheckbox),
+    );
+
+    expect(
+      tester.getTopLeft(directoryCheckbox).dx,
+      tester.getTopLeft(fileCheckbox).dx,
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('defaults to tree view and can switch back to flat list', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrap(
+        BtFileSelectionView(
+          files: _files,
+          selectedIndices: const {0, 1, 2, 3},
+          onSelectionChanged: (_) {},
+        ),
+      ),
+    );
+
+    expect(find.byKey(const ValueKey('bt-tree-dir:Example')), findsOneWidget);
+    expect(find.byType(BtFileTile), findsNothing);
+
+    await tester.tap(find.byKey(const ValueKey('bt-view-list')));
+    await tester.pump();
+
+    expect(find.byKey(const ValueKey('bt-tree-dir:Example')), findsNothing);
+    expect(find.byType(BtFileTile), findsNWidgets(_files.length));
+    expect(find.text('Season 1'), findsWidgets);
+
+    await tester.tap(find.byKey(const ValueKey('bt-view-tree')));
+    await tester.pump();
+    expect(find.byKey(const ValueKey('bt-tree-dir:Example')), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}


### PR DESCRIPTION
  ## Summary

  BitTorrent file selection previously displayed torrent contents as a flat list of full paths, making nested directory structures difficult to understand and requiring files to
  be selected individually.

  This PR adds an expandable tree view as the default while preserving the original flat list as an optional display mode.

  ## Root cause

  `BtFileListWidget` rendered every torrent entry independently and combined file formatting, selection controls, and list rendering in the same module.

  There was no directory model capable of grouping files by path, tracking partial directory selection, or applying a selection change to all files under a directory.

  ## Fix

  - Add `BtFileTreeWidget` to build and render torrent paths as an expandable hierarchy.
  - Normalize both `/` and `\` path separators when constructing the tree.
  - Support selecting or deselecting all descendant files from a directory checkbox.
  - Display checked, unchecked, and indeterminate directory selection states.
  - Keep file and directory checkboxes aligned at the same hierarchy level.
  - Add `BtFileSelectionView` with a tree/list view switch, defaulting to tree view.
  - Preserve the existing `BtFileListWidget` and its flat-list behavior.
  - Extract shared formatting, icons, checkboxes, select-all controls, and selection logic into `bt_file_selection_shared.dart`.
  - Use the shared selection view in torrent preview, magnet metadata selection, and the standalone BT file selection dialog.
  - Update manifest and mobile consumers to import the extracted helpers without changing their existing UI behavior.
  - Add English and Chinese tooltips for the tree/list view controls.
  - Add widget tests covering tree construction, directory selection, partial state, alignment, expansion, and view switching.

  ## Commits

  - `8d1c1fb` `feat(widgets)` — add tree and list views for BitTorrent file selection.

## Screenshot

![BitTorrent file selection tree view](https://github.com/user-attachments/assets/d4949914-9a29-4a83-897c-2552b2baa9d5)
