### PR TITLE
fix: 🐛 [App Feedback] under Status column, the Completed text shows splitted...

### DIFF
--- a/lib/src/widgets/task_list.dart
+++ b/lib/src/widgets/task_list.dart
@@ -341,7 +341,7 @@ class _TaskListState extends State<TaskList> {
             ),
           ),
           SizedBox(
-            width: 60,
+            width: 80,
             child: Center(
               child: Text(
                 s.colStatus,

--- a/lib/src/widgets/task_list_item.dart
+++ b/lib/src/widgets/task_list_item.dart
@@ -167,7 +167,7 @@ class _TaskListItemState extends State<TaskListItem> {
               SizedBox(width: 150, child: _buildProgress(c, m)),
               SizedBox(width: 90, child: _buildSpeed(c)),
               SizedBox(width: 80, child: _buildEta(c)),
-              SizedBox(width: 60, child: _buildStatus(c)),
+              SizedBox(width: 80, child: _buildStatus(c)),
             ],
           ),
         ),
@@ -394,6 +394,8 @@ class _TaskListItemState extends State<TaskListItem> {
     }
     final statusText = Text(
       task.statusText,
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
       style: TextStyle(fontSize: 12, color: statusColor),
     );
     return Center(child: statusText);


### PR DESCRIPTION
Fixes #188.

## Summary

🐛 [App Feedback] under Status column, the Completed text shows splitted apart in seprate lines

## Validation

- Mechanical gate: +4/-2, tests passed
- Adversarial review: approved

---
🤖 AI-authored PR, operated by @yhay81. <!-- tsumugi-ai-disclosure -->