### PR TITLE
fix(web): avoid crypto.randomUUID under non-secure-context deployments

### DIFF
--- a/web/src/lib/cloud/session.ts
+++ b/web/src/lib/cloud/session.ts
@@ -74,12 +74,24 @@ export function clearCloudSession() {
 /** 面板本身固定作为一台 web 设备登录 FluxCloud，与宿主 App 账户状态无关。 */
 export const CLOUD_DEVICE_PLATFORM = 'web'
 
+/** RFC 4122 UUID v4 via crypto.getRandomValues() —— 不同于 crypto.randomUUID()，
+ *  getRandomValues() 无 Secure Context 限制，NAS/Docker 面板经明文 HTTP（非
+ *  localhost）访问时 randomUUID 缺失会直接抛错（见 issue #204），此处规避。 */
+function randomUuidV4(): string {
+  const bytes = new Uint8Array(16)
+  crypto.getRandomValues(bytes)
+  bytes[6] = (bytes[6] & 0x0f) | 0x40 // version 4
+  bytes[8] = (bytes[8] & 0x3f) | 0x80 // variant 10
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
+}
+
 /** 客户端持久设备标识（UUID v4），首次调用生成并落盘，此后永久不变 —— 服务端
  *  devices 表识别"同一设备"的唯一依据。 */
 export function cloudDeviceId(): string {
   const existing = localStorage.getItem(DEVICE_ID_KEY)
   if (existing) return existing
-  const id = crypto.randomUUID()
+  const id = randomUuidV4()
   localStorage.setItem(DEVICE_ID_KEY, id)
   return id
 }


### PR DESCRIPTION
## Repro
Self-hosted `ghcr.io/zerx-lab/fluxdown-server` deployed via Docker on a NAS (飞牛OS) and reached over plain `http://<lan-ip>:17800` (no TLS in front). Logging into the FluxCloud panel throws `crypto.randomUUID is not a function. (In 'crypto.randomUUID()', 'crypto.randomUUID' is undefined)`. Reproduced by transcribing `cloudDeviceId()` verbatim and invoking it against a `crypto` shim exposing only `getRandomValues` (no `randomUUID`) — exactly how Chromium/WebKit expose `window.crypto` on a non-secure origin per the WHATWG Secure Contexts spec (https://developer.mozilla.org/docs/Web/API/Crypto/randomUUID: "available only in secure contexts"). Output matched the reporter's pasted error text verbatim.

## Cause
`web/src/lib/cloud/session.ts`'s `cloudDeviceId()` called `crypto.randomUUID()` unconditionally to mint the panel's persistent FluxCloud device id. `randomUUID()` is spec-restricted to secure contexts (HTTPS, or `http://localhost`); the headless server binds `0.0.0.0:17800` with no built-in TLS, so a typical NAS/Docker deployment reached over plain LAN-IP HTTP is a non-secure origin and the method is simply absent on `window.crypto`. `cloudDeviceId()` runs on every FluxCloud login request (`lib/cloud/client.ts`'s `deviceInfo()`), so login failed immediately.

## Fix
- Add a local `randomUuidV4()` in `web/src/lib/cloud/session.ts` that builds an RFC 4122 v4 UUID from `crypto.getRandomValues()` (setting the version/variant bits per spec) — `getRandomValues()` carries no secure-context restriction, and is already the pattern used for `components/settings/SecuritySettings.tsx`'s token generation.
- Swap `cloudDeviceId()`'s `crypto.randomUUID()` call for `randomUuidV4()`.

## Verification
`bun x tsc -b --noEmit` (web) — clean, no errors. `bun run lint` — unchanged pre-existing warnings only, `session.ts` not flagged. Ran 10,000 iterations of the new generator against both an insecure-context `crypto` shim (no `randomUUID`, matching the reported deployment) and the real environment `crypto` object: all outputs match the RFC 4122 v4 pattern (`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`) with zero collisions, and no exception is thrown under the insecure-context shim (previously threw `TypeError: crypto.randomUUID is not a function`, matching the report verbatim).

Fixes #204