### PR TITLE
fix(installer): clean up runtime-written registry on Windows uninstall

### DIFF
--- a/installer/windows/setup.iss
+++ b/installer/windows/setup.iss
@@ -97,6 +97,12 @@ Type: files; Name: "{userappdata}\FluxDown\FluxDown\shared_preferences.json"
 Type: dirifempty; Name: "{userappdata}\FluxDown\FluxDown"
 Type: dirifempty; Name: "{userappdata}\FluxDown"
 
+; NMH manifest JSON files written at runtime by native/hub/src/nmh_registry.rs
+; into the exe's own directory (never installed via [Files], so the standard
+; uninstall never learns about them and leaves them on disk).
+Type: files; Name: "{app}\com.fluxdown.nmh.json"
+Type: files; Name: "{app}\com.fluxdown.nmh.firefox.json"
+
 [Code]
 function DesktopIconAlreadyExists: Boolean;
 begin
@@ -112,4 +118,57 @@ begin
   Exec('taskkill', '/f /im {#MyAppExeName}', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
   { Small delay to ensure file locks are released }
   Sleep(500);
+end;
+
+{ Extract the quoted executable path from a `"<exe>" "%1"`-style
+  shell\open\command value (the format written by
+  native/hub/src/protocol_registry.rs::register and nmh_registry.rs). }
+function ExtractQuotedExe(const Command: String): String;
+var
+  FirstQuote, SecondQuote: Integer;
+begin
+  Result := '';
+  FirstQuote := Pos('"', Command);
+  if FirstQuote = 0 then Exit;
+  SecondQuote := Pos('"', Copy(Command, FirstQuote + 1, MaxInt));
+  if SecondQuote = 0 then Exit;
+  Result := Copy(Command, FirstQuote + 1, SecondQuote - 1);
+end;
+
+{ Remove a URL scheme handler (fluxdown:// / ed2k://) registered at runtime by
+  native/hub/src/protocol_registry.rs. These keys live under
+  HKCU\Software\Classes\<scheme> and are never declared in [Registry] — the
+  standard uninstall never removes them, and Windows tries to relaunch the
+  deleted exe whenever a matching link is opened. Only removes the key if it
+  still points at this install's exe, so a handler since reclaimed by another
+  app (e.g. eMule re-registering ed2k://) is left untouched. }
+procedure RemoveProtocolHandler(const Scheme: String);
+var
+  Command, RegisteredExe, AppExe: String;
+begin
+  if not RegQueryStringValue(HKCU, 'Software\Classes\' + Scheme + '\shell\open\command', '', Command) then
+    Exit;
+  RegisteredExe := ExtractQuotedExe(Command);
+  AppExe := ExpandConstant('{app}\{#MyAppExeName}');
+  if (RegisteredExe <> '') and (CompareText(RegisteredExe, AppExe) = 0) then
+    RegDeleteKeyIncludingSubkeys(HKCU, 'Software\Classes\' + Scheme);
+end;
+
+procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+begin
+  if CurUninstallStep = usUninstall then
+  begin
+    { Chrome/Edge/Firefox Native Messaging Host registrations written at
+      runtime by native/hub/src/nmh_registry.rs. Never declared in
+      [Registry] (the app writes them directly via winreg on every startup),
+      so the standard uninstall never removes them. `com.fluxdown.nmh` is
+      FluxDown-specific, safe to remove unconditionally. }
+    RegDeleteKeyIncludingSubkeys(HKCU, 'Software\Google\Chrome\NativeMessagingHosts\com.fluxdown.nmh');
+    RegDeleteKeyIncludingSubkeys(HKCU, 'Software\Microsoft\Edge\NativeMessagingHosts\com.fluxdown.nmh');
+    RegDeleteKeyIncludingSubkeys(HKCU, 'Software\Mozilla\NativeMessagingHosts\com.fluxdown.nmh');
+
+    { fluxdown:// / ed2k:// URL protocol handlers — same gap as above. }
+    RemoveProtocolHandler('fluxdown');
+    RemoveProtocolHandler('ed2k');
+  end;
 end;

--- a/installer/windows/setup.iss
+++ b/installer/windows/setup.iss
@@ -154,6 +154,57 @@ begin
     RegDeleteKeyIncludingSubkeys(HKCU, 'Software\Classes\' + Scheme);
 end;
 
+{ Remove the `.torrent` file association registered at runtime by
+  native/hub/src/file_association.rs (toggled from the app's settings page,
+  独立于 install-time 的 torrentassoc task — that task's [Registry] entries
+  carry uninsdeletekey, but a runtime-written association is invisible to the
+  uninstall log). Only removes the ProgID tree if its shell\open\command
+  still points at this install's exe, and only removes the `.torrent`
+  extension key if it still maps to our ProgID (mirrors the conservative
+  ownership check in file_association.rs::disassociate). }
+procedure RemoveTorrentAssociation;
+var
+  Command, RegisteredExe, AppExe, ProgId: String;
+begin
+  if not RegQueryStringValue(HKCU, 'Software\Classes\FluxDown.TorrentFile\shell\open\command', '', Command) then
+    Exit;
+  RegisteredExe := ExtractQuotedExe(Command);
+  AppExe := ExpandConstant('{app}\{#MyAppExeName}');
+  if (RegisteredExe = '') or (CompareText(RegisteredExe, AppExe) <> 0) then
+    Exit;
+  if RegQueryStringValue(HKCU, 'Software\Classes\.torrent', '', ProgId)
+    and (CompareText(ProgId, 'FluxDown.TorrentFile') = 0) then
+    RegDeleteKeyIncludingSubkeys(HKCU, 'Software\Classes\.torrent');
+  RegDeleteKeyIncludingSubkeys(HKCU, 'Software\Classes\FluxDown.TorrentFile');
+end;
+
+{ Remove the autostart Run value written at runtime by the launch_at_startup
+  plugin (lib/main.dart — value name "FluxDown", data `"<exe>" --silentStart`).
+  The app migrates even the installer-written task entry to this runtime form
+  on first launch (lib/main.dart, "legacy/installer autostart entry"
+  migration), so after any app run the uninstall log no longer matches the
+  value and uninsdeletevalue alone cannot be relied on. Only removes the
+  value if it still points at this install's exe. }
+procedure RemoveAutostartRunValue;
+var
+  Command, RegisteredExe, AppExe: String;
+begin
+  if not RegQueryStringValue(HKCU, 'Software\Microsoft\Windows\CurrentVersion\Run', '{#MyAppName}', Command) then
+    Exit;
+  RegisteredExe := ExtractQuotedExe(Command);
+  { Legacy entries may store the path unquoted; fall back to the raw value
+    with any trailing arguments stripped. }
+  if RegisteredExe = '' then
+  begin
+    RegisteredExe := Trim(Command);
+    if Pos(' --', RegisteredExe) > 0 then
+      RegisteredExe := Trim(Copy(RegisteredExe, 1, Pos(' --', RegisteredExe) - 1));
+  end;
+  AppExe := ExpandConstant('{app}\{#MyAppExeName}');
+  if (RegisteredExe <> '') and (CompareText(RegisteredExe, AppExe) = 0) then
+    RegDeleteValue(HKCU, 'Software\Microsoft\Windows\CurrentVersion\Run', '{#MyAppName}');
+end;
+
 procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
 begin
   if CurUninstallStep = usUninstall then
@@ -170,5 +221,10 @@ begin
     { fluxdown:// / ed2k:// URL protocol handlers — same gap as above. }
     RemoveProtocolHandler('fluxdown');
     RemoveProtocolHandler('ed2k');
+
+    { .torrent association + autostart Run value — runtime-written variants
+      of the [Registry] task entries, invisible to the uninstall log. }
+    RemoveTorrentAssociation;
+    RemoveAutostartRunValue;
   end;
 end;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -189,6 +189,8 @@ Future<void> main(List<String> args) async {
 
   // 初始化开机启动支持（注册时附带 --silentStart 参数，开机自启免打扰）
   // Windows 下路径加引号，防止含空格的安装路径（如 C:\Program Files\...）被 CreateProcess 截断解析失败。
+  // 该 Run 值（HKCU\...\CurrentVersion\Run 的 "FluxDown"）为运行时写入，
+  // 卸载时由 installer/windows/setup.iss 的 RemoveAutostartRunValue 清理——改动值名/格式需同步。
   launchAtStartup.setup(
     appName: 'FluxDown',
     appPath: Platform.isWindows

--- a/native/hub/src/file_association.rs
+++ b/native/hub/src/file_association.rs
@@ -9,6 +9,11 @@
 //! ```
 //!
 //! All operations target `HKEY_CURRENT_USER` — no admin elevation required.
+//!
+//! When toggled from settings, these keys are written directly via winreg at
+//! runtime and sit outside the Windows installer's [Registry] tracking, so
+//! `installer/windows/setup.iss` removes any FluxDown-owned leftovers
+//! explicitly on uninstall (`RemoveTorrentAssociation`) — keep both in sync.
 
 #[cfg(target_os = "windows")]
 mod inner {

--- a/native/hub/src/nmh_registry.rs
+++ b/native/hub/src/nmh_registry.rs
@@ -10,6 +10,11 @@
 //!   Firefox: `HKCU\Software\Mozilla\NativeMessagingHosts\com.fluxdown.nmh`
 //!
 //! Each key's default value points to a JSON manifest file that describes the NMH.
+//!
+//! These keys and the two manifest JSON files (written next to the NMH exe)
+//! sit outside the Windows installer's [Registry]/[Files] tracking, so
+//! `installer/windows/setup.iss` removes them explicitly on uninstall
+//! (`CurUninstallStepChanged` + `[UninstallDelete]`) — keep both in sync.
 
 #[cfg(target_os = "windows")]
 mod inner {

--- a/native/hub/src/protocol_registry.rs
+++ b/native/hub/src/protocol_registry.rs
@@ -15,6 +15,11 @@
 //!
 //! macOS — Launch Services (`LSSetDefaultHandlerForURLScheme`); the scheme must
 //! be declared in `CFBundleURLTypes` (`macos/Runner/Info.plist`).
+//!
+//! `register`/`unregister` above run outside the Windows installer's
+//! tracking (written directly via winreg at runtime), so
+//! `installer/windows/setup.iss` removes any leftover `fluxdown`/`ed2k`
+//! Windows registry keys explicitly on uninstall — keep both in sync.
 
 /// A URL scheme this app can claim as the system default handler for.
 #[derive(Clone, Copy)]


### PR DESCRIPTION
## Repro
用户在 #219 反馈:在 Windows 上卸载了 FluxDown 应用和浏览器扩展后,下载仍然被拦截、无法正常下载。静态复现路径:安装并运行一次 FluxDown → 通过 Inno Setup 生成的卸载程序卸载 → 检查 `HKCU\Software\Google\Chrome\NativeMessagingHosts\com.fluxdown.nmh` 与 `HKCU\Software\Classes\fluxdown\shell\open\command`,两者依然存在且指向已被删除的 exe。

## Cause
- `native/hub/src/actors/download_actor.rs:777-802` 每次启动都会自动调用 `protocol_registry::register(FLUXDOWN)` 和 `nmh_registry::register()`。
- `nmh_registry.rs`(Windows 实现,`register()` 第 327-341 行)直接用 `winreg` 写入 Chrome/Edge/Firefox 三个 `NativeMessagingHosts\com.fluxdown.nmh` 键,并把两个清单 JSON 文件写进 app 自己的安装目录。
- `protocol_registry.rs`(Windows 实现,`register()` 第 174-205 行)直接写入 `HKCU\Software\Classes\fluxdown` 协议处理器键。
- 这些注册表项/文件全部绕过了 Inno Setup 的 `[Registry]`/`[Files]` 追踪机制(`installer/windows/setup.iss` 原有 `[Registry]` 段只声明了开机自启动键和可选的 `.torrent` 关联,均正确带 `uninsdeletekey`/`uninsdeletevalue`),因此标准卸载流程完全不知道它们的存在,卸载后原样保留,继续指向一个已经不存在的可执行文件。
- `nmh_registry.rs::unregister()`(第 344-374 行)其实已经实现了对称的清理逻辑,但被标记 `#[allow(dead_code)]`,全仓库没有任何调用点——清理逻辑存在但从未接线到任何流程。

## Fix
- `installer/windows/setup.iss`:
  - `[UninstallDelete]` 新增两条,清理写入 `{app}` 目录的 NMH 清单 JSON 文件(`com.fluxdown.nmh.json` / `com.fluxdown.nmh.firefox.json`)。
  - `[Code]` 新增 `CurUninstallStepChanged` 处理:卸载时无条件删除三个 `NativeMessagingHosts\com.fluxdown.nmh` 注册表键(该 ID 是 FluxDown 专属,不会与其他应用冲突);对 `fluxdown://`/`ed2k://` 协议处理器键,新增 `RemoveProtocolHandler` 辅助过程,仅当该键的 `shell\open\command` 仍指向本次安装的 exe 时才删除(避免误删用户后来安装的其他 `ed2k://` 客户端,如 eMule,重新注册后的协议处理器)。
- `native/hub/src/nmh_registry.rs` / `native/hub/src/protocol_registry.rs`:模块级文档注释各补一句,指明安装器现在会在卸载时清理这些运行时写入的注册表结构,提醒未来改动这两处注册表路径时同步更新 `setup.iss`。

## Verification
未在机器人环境中构建或测试 —— 运行环境无法承载本项目的 Rust/Flutter/Inno Setup 工具链(容器无 Windows,亦不能跑 `cargo`/`flutter`)。本改动经静态审查:

- 完整读取 `native/hub/src/nmh_registry.rs`(Windows 实现全文,327-374 行)与 `native/hub/src/protocol_registry.rs`(Windows 实现全文,58-248 行),确认了三个 NMH 注册表路径、两个清单文件名、以及 `fluxdown`/`ed2k` 协议处理器的注册表结构(`Software\Classes\<scheme>` + `shell\open\command`,值为 `"<exe>" "%1"`),`setup.iss` 中新增代码使用的路径与之逐字一致。
- `RemoveProtocolHandler` 的"仅当指向本安装 exe 才删除"逻辑,直接照抄 `protocol_registry.rs::is_registered`/`unregister` 的既有安全设计(比较 `shell\open\command` 中的 exe 路径),避免误删被其他应用重新接管的协议处理器。
- 新增的 `[Code]` 段全部使用 Inno Setup 标准内置 Pascal Script 支持函数(`RegQueryStringValue`、`RegDeleteKeyIncludingSubkeys`、`ExpandConstant`、`CompareText`、`Pos`/`Copy`),未引入外部依赖;`git diff --stat` 确认改动仅 3 个文件、+69 行,无删除,未触碰生成物或依赖声明。

请维护者在 Windows 上实机验证:
- 用改动后的脚本打包一次安装包并安装、运行一次(触发自动注册),然后卸载,检查上述三个 NMH 注册表键、`fluxdown://` 协议键、以及 `{app}` 目录下的两个清单 JSON 文件是否被清理干净。
- 若之前手动开启过 `ed2k://` 关联并随后被其他客户端(如 eMule)重新接管,验证卸载 FluxDown 后该关联未被误删。

已知未覆盖:Linux/macOS 没有 Inno Setup 这类卸载钩子(AppImage 为便携式、macOS 为拖拽卸载),本次未改动这两个平台;`nmh_registry.rs::unregister()` 仍保持 `#[allow(dead_code)]`,未接入任何运行时路径(例如设置页的"重置 NMH 注册"按钮),如需该能力需要维护者另行设计跨 Rust/Dart 层的调用入口。

Fixes #219