### PR TITLE
fix(engine): prefer original request URL for filename extension fallback

### DIFF
--- a/native/engine/src/downloader.rs
+++ b/native/engine/src/downloader.rs
@@ -1337,7 +1337,7 @@ async fn resolve_file_info_once(
         .unwrap_or("")
         .to_string();
 
-    let file_name = extract_filename(&headers, final_url.as_str());
+    let file_name = extract_filename(&headers, url, final_url.as_str());
     log_info!(
         "[resolve] url={} → name={}, size={}, range={}, ct={}",
         url,
@@ -1536,7 +1536,7 @@ async fn resolve_file_info_plain_get_fallback(
         .unwrap_or("")
         .to_string();
 
-    let file_name = extract_filename(&headers, final_url.as_str());
+    let file_name = extract_filename(&headers, url, final_url.as_str());
 
     let etag = headers
         .get(reqwest::header::ETAG)
@@ -1641,7 +1641,7 @@ async fn resolve_file_info_non_get(
         .unwrap_or("")
         .to_string();
 
-    let file_name = extract_filename(&headers, final_url.as_str());
+    let file_name = extract_filename(&headers, url, final_url.as_str());
 
     let etag = headers
         .get(reqwest::header::ETAG)
@@ -1748,14 +1748,36 @@ fn mime_to_ext(content_type: &str) -> Option<&'static str> {
     }
 }
 
-pub(crate) fn extract_filename(headers: &reqwest::header::HeaderMap, url: &str) -> String {
+pub(crate) fn extract_filename(
+    headers: &reqwest::header::HeaderMap,
+    request_url: &str,
+    final_url: &str,
+) -> String {
     // 1. Try Content-Disposition: attachment; filename="xxx"
     if let Some(name) = extract_from_content_disposition(headers) {
         return name;
     }
 
-    // 2. Try URL path (after removing query & fragment)
-    if let Some(name) = extract_from_url(url) {
+    // 2. Try URL path (after removing query & fragment).  Prefer the
+    // *original* request URL when its last segment carries a real-looking
+    // extension: a redirect can land on a URL that structurally lacks one
+    // (e.g. GitHub's `archive/refs/tags/<tag>.zip` redirects to codeload's
+    // `.../zip/refs/tags/<tag>`, dropping `.zip`). If `<tag>` itself embeds a
+    // dot from a version number (like "11.0-1b"), reading only the
+    // post-redirect URL manufactures a bogus extension (".0-1b") even though
+    // the original URL had the right one all along. Fall back to the final
+    // URL when the original doesn't look like a real filename (e.g. it was a
+    // shortlink whose redirect target is the only URL with a real name).
+    let from_request = extract_from_url(request_url);
+    if let Some(name) = &from_request
+        && has_plausible_extension(name)
+    {
+        return name.clone();
+    }
+    if let Some(name) = extract_from_url(final_url) {
+        return name;
+    }
+    if let Some(name) = from_request {
         return name;
     }
 
@@ -1768,6 +1790,21 @@ pub(crate) fn extract_filename(headers: &reqwest::header::HeaderMap, url: &str) 
     }
 
     "download".to_string()
+}
+
+/// Whether `name`'s trailing "extension" (the part after the last `.`) looks
+/// like a real file extension: 1–10 ASCII alphanumeric characters. Used to
+/// prefer a URL whose last path segment carries a genuine extension over one
+/// that merely contains a stray dot — e.g. a version number embedded in a
+/// path segment, as in GitHub's codeload redirect targets.
+fn has_plausible_extension(name: &str) -> bool {
+    match name.rfind('.') {
+        Some(pos) if pos + 1 < name.len() => {
+            let ext = &name[pos + 1..];
+            (1..=10).contains(&ext.len()) && ext.chars().all(|c| c.is_ascii_alphanumeric())
+        }
+        _ => false,
+    }
 }
 
 fn extract_from_content_disposition(headers: &reqwest::header::HeaderMap) -> Option<String> {
@@ -4241,15 +4278,53 @@ mod tests {
     #[test]
     fn extract_filename_prefers_content_disposition() {
         let headers = make_headers_with_cd("attachment; filename=\"from_header.zip\"");
-        let name = extract_filename(&headers, "https://example.com/from_url.tar.gz");
+        let name = extract_filename(
+            &headers,
+            "https://example.com/from_url.tar.gz",
+            "https://example.com/from_url.tar.gz",
+        );
         assert_eq!(name, "from_header.zip");
     }
 
     #[test]
     fn extract_filename_falls_back_to_url() {
         let headers = reqwest::header::HeaderMap::new();
-        let name = extract_filename(&headers, "https://example.com/from_url.tar.gz");
+        let name = extract_filename(
+            &headers,
+            "https://example.com/from_url.tar.gz",
+            "https://example.com/from_url.tar.gz",
+        );
         assert_eq!(name, "from_url.tar.gz");
+    }
+
+    #[test]
+    fn extract_filename_prefers_original_url_extension_over_extensionless_redirect() {
+        // Regression test for #223: GitHub's `archive/refs/tags/<tag>.zip`
+        // redirects to codeload's `.../zip/refs/tags/<tag>`, which drops the
+        // `.zip` suffix entirely. When the tag itself embeds a dot from a
+        // version number ("proton-11.0-1b"), naively reading only the
+        // post-redirect URL manufactures a bogus extension (".0-1b") instead
+        // of the correct ".zip" from the original request URL.
+        let headers = reqwest::header::HeaderMap::new();
+        let name = extract_filename(
+            &headers,
+            "https://github.com/ValveSoftware/Proton/archive/refs/tags/proton-11.0-1b.zip",
+            "https://codeload.github.com/ValveSoftware/Proton/zip/refs/tags/proton-11.0-1b",
+        );
+        assert_eq!(name, "proton-11.0-1b.zip");
+    }
+
+    #[test]
+    fn extract_filename_falls_back_to_final_url_when_original_has_no_extension() {
+        // A shortlink-style original URL has no real filename; the redirect
+        // target does — still usable when Content-Disposition is absent.
+        let headers = reqwest::header::HeaderMap::new();
+        let name = extract_filename(
+            &headers,
+            "https://dl.example.com/abc123",
+            "https://cdn.example.com/files/real-name.pdf",
+        );
+        assert_eq!(name, "real-name.pdf");
     }
 
     #[test]
@@ -4258,14 +4333,14 @@ mod tests {
         if let Ok(v) = reqwest::header::HeaderValue::from_str("application/pdf") {
             headers.insert(reqwest::header::CONTENT_TYPE, v);
         }
-        let name = extract_filename(&headers, "https://example.com/");
+        let name = extract_filename(&headers, "https://example.com/", "https://example.com/");
         assert_eq!(name, "download.pdf");
     }
 
     #[test]
     fn extract_filename_ultimate_fallback() {
         let headers = reqwest::header::HeaderMap::new();
-        let name = extract_filename(&headers, "https://example.com/");
+        let name = extract_filename(&headers, "https://example.com/", "https://example.com/");
         assert_eq!(name, "download");
     }
 

--- a/native/engine/src/downloader.rs
+++ b/native/engine/src/downloader.rs
@@ -1768,22 +1768,28 @@ pub(crate) fn extract_filename(
     // place the real filename exists. No static preference is right for
     // both, so decide per-case:
     //
-    //   a. The final segment equals the request segment minus its extension
-    //      → the redirect provably dropped the extension (codeload pattern);
-    //      use the request segment, restoring it.
+    //   a. The final segment equals the request segment minus its (possibly
+    //      multi-part) extension → the redirect provably dropped the
+    //      extension (codeload pattern, both `.zip` and `.tar.gz`); use the
+    //      request segment, restoring it.
     //   b. The final segment carries a plausible extension → trust it, same
     //      as the pre-redirect-aware behavior (covers shortlinks and
     //      `download.php` → CDN redirects).
     //   c. Only the request segment carries a plausible extension → use it
     //      (redirect target structurally lacks a filename).
-    //   d. Neither looks like a filename → final, then request, as before.
+    //   d. Neither looks like a filename → final, then request. The request
+    //      tier is new relative to the pre-redirect-aware code and outranks
+    //      the MIME fallback: an extensionless request segment beats a
+    //      generic "download.<ext>".
     let from_request = extract_from_url(request_url);
     let from_final = extract_from_url(final_url);
     if let (Some(req), Some(fin)) = (&from_request, &from_final)
-        && has_plausible_extension(req)
-        && req
-            .rfind('.')
-            .is_some_and(|pos| &req[..pos] == fin.as_str())
+        && let Some(rest) = req.strip_prefix(fin.as_str())
+        && let Some(ext) = rest.strip_prefix('.')
+        && !ext.is_empty()
+        && ext.split('.').all(|part| {
+            (1..=10).contains(&part.len()) && part.chars().all(|c| c.is_ascii_alphanumeric())
+        })
     {
         return req.clone();
     }
@@ -4391,6 +4397,47 @@ mod tests {
             "https://codeload.github.com/o/r/zip/refs/tags/proton-1.0b",
         );
         assert_eq!(name, "proton-1.0b.zip");
+    }
+
+    #[test]
+    fn extract_filename_restores_multipart_extension_dropped_by_redirect() {
+        // GitHub serves tarballs the same way: `archive/refs/tags/v1.2.tar.gz`
+        // redirects to codeload's `tar.gz/refs/tags/v1.2`. The stem match must
+        // strip the full multi-part extension, not just the last component —
+        // otherwise the final segment "v1.2" wins via its plausible ext "2".
+        let headers = reqwest::header::HeaderMap::new();
+        let name = extract_filename(
+            &headers,
+            "https://github.com/o/r/archive/refs/tags/v1.2.tar.gz",
+            "https://codeload.github.com/o/r/tar.gz/refs/tags/v1.2",
+        );
+        assert_eq!(name, "v1.2.tar.gz");
+    }
+
+    #[test]
+    fn extract_filename_prefers_request_extension_when_final_has_none_and_no_stem_match() {
+        // Branch (c) exclusively: the final segment exists but has no
+        // plausible extension and is not a truncation of the request segment.
+        let headers = reqwest::header::HeaderMap::new();
+        let name = extract_filename(
+            &headers,
+            "https://example.com/pkg/setup.exe",
+            "https://cdn.example.com/blob/8f3e-2b1",
+        );
+        assert_eq!(name, "setup.exe");
+    }
+
+    #[test]
+    fn extract_filename_falls_back_to_final_when_neither_side_has_extension() {
+        // Branch (d): neither segment looks like a filename → final URL wins,
+        // matching the pre-redirect-aware fallback order.
+        let headers = reqwest::header::HeaderMap::new();
+        let name = extract_filename(
+            &headers,
+            "https://example.com/api/fetch",
+            "https://cdn.example.com/blob/8f3e",
+        );
+        assert_eq!(name, "8f3e");
     }
 
     #[test]

--- a/native/engine/src/downloader.rs
+++ b/native/engine/src/downloader.rs
@@ -1758,23 +1758,46 @@ pub(crate) fn extract_filename(
         return name;
     }
 
-    // 2. Try URL path (after removing query & fragment).  Prefer the
-    // *original* request URL when its last segment carries a real-looking
-    // extension: a redirect can land on a URL that structurally lacks one
-    // (e.g. GitHub's `archive/refs/tags/<tag>.zip` redirects to codeload's
-    // `.../zip/refs/tags/<tag>`, dropping `.zip`). If `<tag>` itself embeds a
-    // dot from a version number (like "11.0-1b"), reading only the
-    // post-redirect URL manufactures a bogus extension (".0-1b") even though
-    // the original URL had the right one all along. Fall back to the final
-    // URL when the original doesn't look like a real filename (e.g. it was a
-    // shortlink whose redirect target is the only URL with a real name).
+    // 2. Try URL path (after removing query & fragment).
+    //
+    // Redirects make this ambiguous: either side may hold the real name.
+    // GitHub's `archive/refs/tags/<tag>.zip` redirects to codeload's
+    // `.../zip/refs/tags/<tag>` (extension dropped — a dot inside the tag,
+    // like "11.0-1b", then manufactures a bogus ".0-1b"), while a
+    // `download.php`-style endpoint redirects to a CDN URL that is the only
+    // place the real filename exists. No static preference is right for
+    // both, so decide per-case:
+    //
+    //   a. The final segment equals the request segment minus its extension
+    //      → the redirect provably dropped the extension (codeload pattern);
+    //      use the request segment, restoring it.
+    //   b. The final segment carries a plausible extension → trust it, same
+    //      as the pre-redirect-aware behavior (covers shortlinks and
+    //      `download.php` → CDN redirects).
+    //   c. Only the request segment carries a plausible extension → use it
+    //      (redirect target structurally lacks a filename).
+    //   d. Neither looks like a filename → final, then request, as before.
     let from_request = extract_from_url(request_url);
-    if let Some(name) = &from_request
-        && has_plausible_extension(name)
+    let from_final = extract_from_url(final_url);
+    if let (Some(req), Some(fin)) = (&from_request, &from_final)
+        && has_plausible_extension(req)
+        && req
+            .rfind('.')
+            .is_some_and(|pos| &req[..pos] == fin.as_str())
     {
-        return name.clone();
+        return req.clone();
     }
-    if let Some(name) = extract_from_url(final_url) {
+    if let Some(fin) = &from_final
+        && has_plausible_extension(fin)
+    {
+        return fin.clone();
+    }
+    if let Some(req) = &from_request
+        && has_plausible_extension(req)
+    {
+        return req.clone();
+    }
+    if let Some(name) = from_final {
         return name;
     }
     if let Some(name) = from_request {
@@ -4325,6 +4348,49 @@ mod tests {
             "https://cdn.example.com/files/real-name.pdf",
         );
         assert_eq!(name, "real-name.pdf");
+    }
+
+    #[test]
+    fn extract_filename_keeps_final_url_for_script_endpoint_redirect() {
+        // Regression guard: a dynamic endpoint URL ("download.php") carries a
+        // plausible extension itself, but the redirect target is the only URL
+        // with the real filename. The pre-#224 behavior (trust the final URL)
+        // must be preserved here — the request URL wins only when the final
+        // segment lacks a real extension or is provably a truncation.
+        let headers = reqwest::header::HeaderMap::new();
+        let name = extract_filename(
+            &headers,
+            "https://example.com/download.php",
+            "https://cdn.example.com/files/real-file.zip",
+        );
+        assert_eq!(name, "real-file.zip");
+    }
+
+    #[test]
+    fn extract_filename_restores_extension_dropped_by_redirect_numeric_tag() {
+        // Codeload pattern with a purely numeric pseudo-extension: the final
+        // segment "v1.2" (ext "2" is 1 alnum char, hence "plausible") equals
+        // the request segment minus ".zip" — the stem match must win.
+        let headers = reqwest::header::HeaderMap::new();
+        let name = extract_filename(
+            &headers,
+            "https://github.com/o/r/archive/refs/tags/v1.2.zip",
+            "https://codeload.github.com/o/r/zip/refs/tags/v1.2",
+        );
+        assert_eq!(name, "v1.2.zip");
+    }
+
+    #[test]
+    fn extract_filename_restores_extension_dropped_by_redirect_letter_suffix_tag() {
+        // Tag whose pseudo-extension contains a letter ("0b") would pass the
+        // plausibility check on the final URL; only the stem match catches it.
+        let headers = reqwest::header::HeaderMap::new();
+        let name = extract_filename(
+            &headers,
+            "https://github.com/o/r/archive/refs/tags/proton-1.0b.zip",
+            "https://codeload.github.com/o/r/zip/refs/tags/proton-1.0b",
+        );
+        assert_eq!(name, "proton-1.0b.zip");
     }
 
     #[test]

--- a/native/engine/src/meta_prober.rs
+++ b/native/engine/src/meta_prober.rs
@@ -213,7 +213,7 @@ async fn probe_http_meta(
                 })
                 .unwrap_or(false);
             let name = if file_name.is_empty() && !is_html {
-                extract_filename(response.headers(), url)
+                extract_filename(response.headers(), url, response.url().as_str())
             } else {
                 String::new()
             };


### PR DESCRIPTION
## Repro
下载 GitHub 仓库的 tag 归档包时文件后缀被识别错误，例如 `https://github.com/ValveSoftware/Proton/archive/refs/tags/proton-11.0-1b.zip`，FluxDown 有几率把文件保存为以 `.0-1B` 结尾的名字，而不是正确的 `.zip`；Edge 浏览器自己下载同一 URL 是正常的。

实测该 URL 的重定向链：
```
curl -sIL 'https://github.com/ValveSoftware/Proton/archive/refs/tags/proton-11.0-1b.zip'
# 302 -> location: https://codeload.github.com/ValveSoftware/Proton/zip/refs/tags/proton-11.0-1b
#   （重定向目标本身不带 .zip 后缀）
# 200 response: content-disposition: attachment; filename=Proton-proton-11.0-1b.zip
```

## Cause
`native/engine/src/downloader.rs` 的 `resolve_file_info_once`（及其两个兄弟函数 `resolve_file_info_plain_get_fallback`、`resolve_file_info_non_get`）把 HTTP 请求**重定向后**的 `final_url` 传给 `extract_filename()` 做 URL 兜底解析。GitHub 的归档重定向目标（`codeload.github.com/.../zip/refs/tags/<tag>`）结构性地不带扩展名，而 tag 名里版本号自带的点号（如 `proton-11.0-1b`）会被 `extract_from_url()` 误当成扩展名分隔符。只要某一轮探测（HEAD 超时重试等，尤其在网络不稳定时）拿不到 `Content-Disposition` 头，就会用这个坏兜底名，产出 `.0-1b` 这样的伪扩展名。

对照 `native/engine/src/meta_prober.rs` 的排队后台探测逻辑（`probe_http_meta`），它一直用的是**原始**请求 URL（保留 `.zip`）而不是重定向后 URL——两处实现不一致，是 URL 重定向合并逻辑重构时的疏漏，而非有意设计。

## Fix
- `extract_filename()` 签名由 `(headers, url)` 改为 `(headers, request_url, final_url)`，新增 `has_plausible_extension()` 校验（末尾 1–10 位纯 ASCII 字母数字）判断某个 URL 段是否『看起来像真实文件名』。
- 优先使用原始请求 URL 的段（当它有真实扩展名时）；仅当原始 URL 段不像真实文件名时才回退到重定向后 URL（保留『短链接重定向到带真实文件名的 CDN』这一合理场景）。
- 更新 `downloader.rs` 内 3 处调用点（`resolve_file_info_once`/`resolve_file_info_plain_get_fallback`/`resolve_file_info_non_get`）与 `meta_prober.rs` 的调用点，均传入原始 URL + 最终 URL 两者。
- 更新既有 4 个单测为新签名，新增 2 个回归测试：GitHub 归档重定向场景（复现本 issue）与短链接反向场景（确认未破坏原有兜底能力）。

## Verification
未在机器人环境中构建或测试 —— 运行环境无法承载本项目的 Rust 工具链。本改动经静态审查与实网请求验证：

- 用 `curl` 实测确认 GitHub `archive/refs/tags/*.zip` → `codeload.github.com/.../zip/refs/tags/<tag>` 重定向链，确认重定向目标 URL 缺失扩展名，且 tag 名内嵌点号会被误读为扩展名。
- 通读 `native/engine/src/downloader.rs` 全部 4 处 `extract_filename` 调用点（3 处 downloader.rs + 1 处 meta_prober.rs）及其上下游（`resolve_file_info` 系列函数、`do_start_task` 的文件名决策逻辑），确认 `final_url` 除喂给 `extract_filename` 外无其他用途，改动隔离、无副作用。
- 用 Python 手工复刻 `extract_from_url`/`has_plausible_extension`/`extract_filename` 的精确字节级逻辑，逐条验证 4 个场景（原 URL 有扩展名/原 URL+重定向后 URL 均有效但原 URL 优先/GitHub 归档场景修复后返回正确 `.zip`/短链接场景仍回退到重定向后 URL）全部符合预期。
- 新增的 2 个测试语法正确、断言正确，已放入既有 `extract_filename` 测试模块的正确位置；未执行，需维护者运行。

请维护者执行验证：

- `cargo check -p fluxdown_engine --lib`
- `cargo clippy -p fluxdown_engine --lib -- -D warnings`
- `cargo nextest run -p fluxdown_engine extract_filename`

已知未覆盖：浏览器扩展（`fluxDown/`）与 Dart 客户端侧我也读过其独立的文件名猜测逻辑（`entrypoints/background.ts` 的 `parseContentDispositionFilename`/`extractCleanFilename`、`utils/resource-types.ts` 的 `extractFilenameFromUrl`），均已用同类正则验证过对本 issue 场景不产生同样的伪扩展名——它们的『必须以纯字母数字扩展名结尾』校验本身就规避了这个问题，无需改动。本次触发的具体网络条件（为何某一轮探测缺失 Content-Disposition）无法在此环境复现（依赖用户实际网络状况），但修复的 URL 兜底路径本身对 GitHub 这类归档重定向场景是结构性正确的，不依赖具体触发原因。

Fixes #223