### PR TITLE
feat: 新增「清理丢失文件」按钮 + 自动清理开关

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -1527,5 +1527,17 @@
   "searchKeywordsWebhookLog": "webhook log,delivery,deliveries,debug",
   "webhookLogFilterLabel": "Endpoint",
   "webhookLogPending": "Delivering…",
-  "webhookSimulateNoTarget": "No target subscribes to task.completed — nothing was sent."
+  "webhookSimulateNoTarget": "No target subscribes to task.completed — nothing was sent.",
+  "autoCleanupMissingFiles": "Auto-cleanup missing file records",
+  "autoCleanupMissingFilesDesc": "Automatically remove task records whose downloaded files no longer exist on disk. The cleanup runs after each file scan.",
+  "cleanupMissingFiles": "Clean up missing file records",
+  "cleanupMissingFilesDesc": "Remove completed task records whose downloaded files no longer exist on disk.",
+  "cleanupMissingFilesConfirm": "Found {n} task record(s) with missing files. These records will be permanently removed. This action cannot be undone.",
+  "cleanupMissingFilesResult": "Removed {n} task record(s).",
+  "cleanupMissingFilesHealed": "Kept {n} task record(s): their files reappeared on disk, marked as present.",
+  "noMissingFilesToClean": "No missing-file records found.",
+  "searchKeywordsMissingCleanup": "clean up,missing file,delete record,auto cleanup,lost file",
+  "missingCleanupTimeout": "Request timed out — please try again.",
+  "missingCleanupExecTimeout": "Cleanup timed out — the engine may still be running it in the background.",
+  "cleanupInProgress": "Cleanup is already in progress — please wait."
 }

--- a/assets/i18n/zh.json
+++ b/assets/i18n/zh.json
@@ -1527,5 +1527,17 @@
   "searchKeywordsWebhookLog": "推送记录,投递日志,webhook 日志,调试,送达",
   "webhookLogFilterLabel": "推送目标",
   "webhookLogPending": "投递中…",
-  "webhookSimulateNoTarget": "没有目标订阅「完成」事件，这次没有发出任何请求。"
+  "webhookSimulateNoTarget": "没有目标订阅「完成」事件，这次没有发出任何请求。",
+  "autoCleanupMissingFiles": "自动清理丢失文件的任务",
+  "autoCleanupMissingFilesDesc": "开启后，每次文件扫描完成后自动移除已完成但文件已不存在的任务记录。",
+  "cleanupMissingFiles": "清理丢失文件的任务",
+  "cleanupMissingFilesDesc": "移除已完成但下载文件已不存在的任务记录。",
+  "cleanupMissingFilesConfirm": "发现 {n} 个文件已丢失的任务记录，将永久移除。此操作不可撤销。",
+  "cleanupMissingFilesResult": "已移除 {n} 个任务记录。",
+  "cleanupMissingFilesHealed": "{n} 个任务的文件已找回，已保留记录并恢复标记。",
+  "noMissingFilesToClean": "没有发现丢失文件的任务记录。",
+  "searchKeywordsMissingCleanup": "清理,丢失文件,删除记录,自动清理,文件不存在",
+  "missingCleanupTimeout": "请求超时，请重试。",
+  "missingCleanupExecTimeout": "清理请求超时——引擎可能仍在后台执行，结果稍后生效。",
+  "cleanupInProgress": "清理正在进行中，请稍后再试。"
 }

--- a/lib/src/i18n/translations.dart
+++ b/lib/src/i18n/translations.dart
@@ -929,6 +929,22 @@ class S {
   String get selectDefaultSaveDir => _r('selectDefaultSaveDir');
   String get rememberLastSaveDir => _r('rememberLastSaveDir');
   String get rememberLastSaveDirDesc => _r('rememberLastSaveDirDesc');
+  String get autoCleanupMissingFiles => _r('autoCleanupMissingFiles');
+  String get autoCleanupMissingFilesDesc => _r('autoCleanupMissingFilesDesc');
+  String get cleanupMissingFiles => _r('cleanupMissingFiles');
+  String get cleanupMissingFilesDesc => _r('cleanupMissingFilesDesc');
+  String cleanupMissingFilesConfirm(int n) =>
+      _r('cleanupMissingFilesConfirm', {'n': n});
+  String cleanupMissingFilesResult(int n) =>
+      _r('cleanupMissingFilesResult', {'n': n});
+  String cleanupMissingFilesHealed(int n) =>
+      _r('cleanupMissingFilesHealed', {'n': n});
+  String get noMissingFilesToClean => _r('noMissingFilesToClean');
+  List<String> get searchKeywordsMissingCleanup =>
+      _r('searchKeywordsMissingCleanup').split(',');
+  String get missingCleanupTimeout => _r('missingCleanupTimeout');
+  String get missingCleanupExecTimeout => _r('missingCleanupExecTimeout');
+  String get cleanupInProgress => _r('cleanupInProgress');
   String get defaultThreads => _r('defaultThreads');
   String get defaultThreadsDesc => _r('defaultThreadsDesc');
   String get autoMaxConnections => _r('autoMaxConnections');

--- a/lib/src/models/settings_provider.dart
+++ b/lib/src/models/settings_provider.dart
@@ -199,6 +199,9 @@ class SettingsProvider extends ChangeNotifier {
   // 下载位置自动使用上次保存的位置（开启后新建下载默认目录跟随上次下载的目录）
   bool _rememberLastSaveDir = false;
 
+  // 文件扫描完成后自动清理「已完成但文件确证丢失」的任务记录（默认关）
+  bool _autoCleanupMissingFiles = false;
+
   // 上次下载确认时使用的保存目录（'' = 未记录）
   String _lastSaveDir = '';
 
@@ -459,6 +462,7 @@ class SettingsProvider extends ChangeNotifier {
   // 记住上次保存位置 Getters
   bool get rememberLastSaveDir => _rememberLastSaveDir;
   String get lastSaveDir => _lastSaveDir;
+  bool get autoCleanupMissingFiles => _autoCleanupMissingFiles;
 
   /// 生效的默认保存目录：开关开启且已有记录时返回上次保存位置，否则返回固定默认目录
   String get effectiveDefaultSaveDir =>
@@ -550,6 +554,13 @@ class SettingsProvider extends ChangeNotifier {
     _rememberLastSaveDir = value;
     notifyListeners();
     _saveToRust('remember_last_save_dir', value.toString());
+  }
+
+  void setAutoCleanupMissingFiles(bool value) {
+    if (_autoCleanupMissingFiles == value) return;
+    _autoCleanupMissingFiles = value;
+    notifyListeners();
+    _saveToRust('auto_cleanup_missing_files', value.toString());
   }
 
   /// 记录下载确认时使用的保存目录（无条件记录，开关开启后立即生效）
@@ -1957,6 +1968,8 @@ class SettingsProvider extends ChangeNotifier {
           _lastTargetDevice = entry.value;
         case 'remember_last_save_dir':
           _rememberLastSaveDir = entry.value == 'true';
+        case 'auto_cleanup_missing_files':
+          _autoCleanupMissingFiles = entry.value == 'true';
         case 'last_save_dir':
           _lastSaveDir = entry.value;
         case 'reveal_file_cmd':

--- a/lib/src/pages/settings_page.dart
+++ b/lib/src/pages/settings_page.dart
@@ -359,6 +359,20 @@ List<SettingsSearchItem> get settingsSearchItems {
     ),
     SettingsSearchItem(
       category: SettingsCategory.download,
+      label: s.autoCleanupMissingFiles,
+      description: s.autoCleanupMissingFilesDesc,
+      keywords: s.searchKeywordsMissingCleanup,
+      icon: LucideIcons.trash2,
+    ),
+    SettingsSearchItem(
+      category: SettingsCategory.download,
+      label: s.cleanupMissingFiles,
+      description: s.cleanupMissingFilesDesc,
+      keywords: s.searchKeywordsMissingCleanup,
+      icon: LucideIcons.fileX,
+    ),
+    SettingsSearchItem(
+      category: SettingsCategory.download,
       label: s.useServerTime,
       description: s.useServerTimeDesc,
       keywords: s.searchKeywordsUseServerTime,
@@ -3161,6 +3175,24 @@ class _DownloadContent extends StatelessWidget {
                           settingsProvider.setSilentSkipSelection(v),
                     ),
                   ),
+                _SettingRow(
+                  label: s.autoCleanupMissingFiles,
+                  description: s.autoCleanupMissingFilesDesc,
+                  child: ShadSwitch(
+                    value: settingsProvider.autoCleanupMissingFiles,
+                    onChanged: (v) =>
+                        settingsProvider.setAutoCleanupMissingFiles(v),
+                  ),
+                ),
+                _SettingRow(
+                  label: s.cleanupMissingFiles,
+                  description: s.cleanupMissingFilesDesc,
+                  child: ShadButton.outline(
+                    size: ShadButtonSize.sm,
+                    onPressed: () => _showMissingCleanupDialog(context),
+                    child: Text(s.cleanupMissingFiles),
+                  ),
+                ),
                 _SettingRow(
                   label: s.useServerTime,
                   description: s.useServerTimeDesc,
@@ -14293,5 +14325,137 @@ class _RegisterDialogContentState extends State<_RegisterDialogContent> {
         ],
       ),
     );
+  }
+}
+
+/// 防重入守卫：弹窗未关闭前再次点击只 toast，不重复请求。
+final _cleanupGuard = ValueNotifier<bool>(false);
+
+/// 「清理丢失文件的任务」手动入口：拉候选 → 确认弹窗 → 执行 → 结果 toast。
+///
+/// 请求-响应以 `requestId` 配对（同 `WebhookTestResult` 先例）：超时重试
+/// 后到达的过期响应被 `firstWhere` 滤掉，不会被新一轮订阅误消费。
+/// 超时窗口与引擎上限配套：候选 35s（引擎 BT staging 收集 30s 总包 +
+/// DB 余量）、执行 120s（N×1s TOCTOU + N×5s staging + 删除）。
+Future<void> _showMissingCleanupDialog(BuildContext context) async {
+  final s = LocaleScope.of(context);
+  void toast(String message) {
+    if (context.mounted) {
+      FluxSonner.of(context).show(ShadToast(title: Text(message)));
+    }
+  }
+
+  if (_cleanupGuard.value) {
+    toast(s.cleanupInProgress);
+    return;
+  }
+  _cleanupGuard.value = true;
+  try {
+    final candidatesReqId = 'mc-${DateTime.now().microsecondsSinceEpoch}';
+    final resultFuture = MissingCleanupCandidatesResult.rustSignalStream
+        .firstWhere((p) => p.message.requestId == candidatesReqId);
+    try {
+      GetMissingCleanupCandidates(
+        requestId: candidatesReqId,
+      ).sendSignalToRust();
+    } catch (_) {
+      toast(s.missingCleanupTimeout);
+      return;
+    }
+    final RustSignalPack<MissingCleanupCandidatesResult> result;
+    try {
+      result = await resultFuture.timeout(const Duration(seconds: 35));
+    } on TimeoutException {
+      toast(s.missingCleanupTimeout);
+      return;
+    } catch (_) {
+      toast(s.missingCleanupTimeout);
+      return;
+    }
+    final candidates = result.message.candidates;
+    if (!context.mounted) return;
+
+    if (candidates.isEmpty) {
+      toast(s.noMissingFilesToClean);
+      return;
+    }
+
+    final confirmed = await showShadDialog<bool>(
+      context: context,
+      barrierColor: AppColors.of(context).dialogBarrier,
+      animateIn: const [],
+      animateOut: const [],
+      builder: (ctx) => ShadDialog(
+        title: Text(s.cleanupMissingFiles),
+        description: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(s.cleanupMissingFilesConfirm(candidates.length)),
+            // 小候选集直接列出文件名——破坏性确认所见即所得。
+            if (candidates.length <= 5) ...[
+              const SizedBox(height: 8),
+              for (final t in candidates)
+                Text(
+                  '\u2022 ${t.fileName}',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+            ],
+          ],
+        ),
+        actions: [
+          ShadButton.outline(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: Text(LocaleScope.of(ctx).cancel),
+          ),
+          ShadButton.destructive(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: Text(LocaleScope.of(ctx).confirm),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true || !context.mounted) return;
+
+    final execReqId = 'mx-${DateTime.now().microsecondsSinceEpoch}';
+    final execFuture = MissingCleanupExecuted.rustSignalStream.firstWhere(
+      (p) => p.message.requestId == execReqId,
+    );
+    try {
+      ExecuteMissingCleanup(
+        requestId: execReqId,
+        taskIds: candidates.map((t) => t.taskId).toList(),
+      ).sendSignalToRust();
+    } catch (_) {
+      toast(s.missingCleanupExecTimeout);
+      return;
+    }
+    final RustSignalPack<MissingCleanupExecuted> execResult;
+    try {
+      execResult = await execFuture.timeout(const Duration(seconds: 120));
+    } on TimeoutException {
+      toast(s.missingCleanupExecTimeout);
+      return;
+    } catch (_) {
+      toast(s.missingCleanupExecTimeout);
+      return;
+    }
+
+    if (context.mounted) {
+      final msg = execResult.message;
+      FluxSonner.of(context).show(
+        ShadToast(
+          title: Text(s.cleanupMissingFilesResult(msg.deleted)),
+          // healed 语义是「文件找回、未删除」，与 deleted 分开表述。
+          description: msg.healed > 0
+              ? Text(s.cleanupMissingFilesHealed(msg.healed))
+              : null,
+        ),
+      );
+    }
+  } finally {
+    _cleanupGuard.value = false;
   }
 }

--- a/lib/src/services/cloud/sync_catalog.dart
+++ b/lib/src/services/cloud/sync_catalog.dart
@@ -441,6 +441,11 @@ List<SyncEntry> buildSyncCatalog({
     () => settings.keepAwakeWhileDownloading,
     settings.setKeepAwakeWhileDownloading,
   ),
+  _bool(
+    'download.auto_cleanup_missing_files',
+    () => settings.autoCleanupMissingFiles,
+    settings.setAutoCleanupMissingFiles,
+  ),
 
   // ── bt（5 + 7 做种）──
   _bool('bt.enable_dht', () => settings.btEnableDht, settings.setBtEnableDht),

--- a/native/engine/src/db.rs
+++ b/native/engine/src/db.rs
@@ -70,6 +70,7 @@ CREATE TABLE IF NOT EXISTS tasks (
     orig_last_modified TEXT NOT NULL DEFAULT '',
     audio_url TEXT NOT NULL DEFAULT '',
     file_missing INTEGER NOT NULL DEFAULT 0,
+    file_present_at INTEGER NOT NULL DEFAULT 0,
     range_verified INTEGER NOT NULL DEFAULT 1,
     queue_order INTEGER NOT NULL DEFAULT 0,
     uploaded_bytes BIGINT NOT NULL DEFAULT 0,
@@ -220,6 +221,8 @@ CREATE TABLE IF NOT EXISTS webhook_deliveries (
     error TEXT NOT NULL DEFAULT ''
 );
 CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_ts ON webhook_deliveries(timestamp_ms);
+CREATE INDEX IF NOT EXISTS idx_tasks_missing_cleanup ON tasks(created_at DESC)
+    WHERE status = 3 AND file_missing = 1;
 ";
 
 /// 建表 DDL（PostgreSQL 方言）。
@@ -250,6 +253,7 @@ CREATE TABLE IF NOT EXISTS tasks (
     orig_last_modified TEXT NOT NULL DEFAULT '',
     audio_url TEXT NOT NULL DEFAULT '',
     file_missing INTEGER NOT NULL DEFAULT 0,
+    file_present_at INTEGER NOT NULL DEFAULT 0,
     range_verified INTEGER NOT NULL DEFAULT 1,
     queue_order INTEGER NOT NULL DEFAULT 0,
     uploaded_bytes BIGINT NOT NULL DEFAULT 0,
@@ -400,6 +404,8 @@ CREATE TABLE IF NOT EXISTS webhook_deliveries (
     error TEXT NOT NULL DEFAULT ''
 );
 CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_ts ON webhook_deliveries(timestamp_ms);
+CREATE INDEX IF NOT EXISTS idx_tasks_missing_cleanup ON tasks(created_at DESC)
+    WHERE status = 3 AND file_missing = 1;
 ";
 
 /// SQLite 连接级 PRAGMA（在 `after_connect` 钩子中对每个新连接执行）。
@@ -418,6 +424,15 @@ const SQLITE_PRAGMAS: &str = "PRAGMA journal_mode=WAL;\
 pub struct Db {
     pool: sqlx::AnyPool,
     backend: Backend,
+}
+
+#[cfg(test)]
+impl Db {
+    /// 测试专用的连接池句柄——供跨模块测试构造故障/精确字段场景
+    /// （如 DROP TABLE 触发降级、绕开盖章逻辑直写行）。生产代码不可见。
+    pub(crate) fn test_pool(&self) -> &sqlx::AnyPool {
+        &self.pool
+    }
 }
 
 /// 把 `AnyRow` 手动映射为 [`TaskInfo`]（列名 `id`→字段 `task_id`）。
@@ -465,6 +480,14 @@ fn task_from_row(row: &AnyRow) -> Result<TaskInfo, sqlx::Error> {
 }
 
 const TASK_COLUMNS: &str = "id, url, file_name, save_dir, status, downloaded_bytes, total_bytes, error_message, created_at, proxy_url, queue_id, checksum, ignore_tls_errors, file_missing, completed_at, segments, queue_order, uploaded_bytes, uploaded_at_completion, seeding_status, seeding_message, seeding_time_secs, seed_ratio_limit_milli, seed_post_ratio_limit_milli, seed_time_limit_minutes, seed_inactive_time_limit_minutes, seed_upload_limit_bps, referrer, group_id, rss_source_id, origin_url, auto_route";
+
+/// 「丢失文件清理」资格谓词：[`Db::load_missing_cleanup_candidates`] 与
+/// [`Db::is_missing_cleanup_candidate`] 共用，保证批量预览与执行前复核
+/// 语义严格一致。`seeding_status` 字面量对应 `crate::bt_seeding` 的
+/// `SEEDING_STATUS_ACTIVE`(1) / `SEEDING_STATUS_QUEUED`(8)。
+const MISSING_CLEANUP_WHERE: &str = "status = 3 AND file_missing = 1 \
+     AND (downloaded_bytes > 0 OR file_present_at > 0) \
+     AND seeding_status NOT IN (1, 8)";
 
 /// 把 `AnyRow` 映射为 [`GroupInfo`]。
 fn group_from_row(row: &AnyRow) -> Result<GroupInfo, sqlx::Error> {
@@ -621,6 +644,14 @@ impl Db {
         // 完成（status→3）的时刻，插件 onDone 等 hook 后处理不计入；任务
         // 重新开始下载（status→0/1/5）时清空，供重下后重新记录。
         self.add_column_if_missing("tasks", "completed_at", "TEXT NOT NULL DEFAULT ''")
+            .await?;
+        // 文件曾确证存在于最终路径的时刻（Unix 秒，0 = 从未确证）。任务
+        // 完成（status→3）时由 update_task_status 盖章——所有协议在进终态前
+        // 都已把数据落到最终路径。「丢失文件清理」用它把「文件被用户删了」
+        // 与「文件从未落盘」（0 字节任务/建文件前即失败）区分开。不进
+        // TASK_COLUMNS/TaskInfo，仅在 WHERE 子句消费（同 seeding_started_at
+        // 的库内私有列先例）。
+        self.add_column_if_missing("tasks", "file_present_at", "INTEGER NOT NULL DEFAULT 0")
             .await?;
         // 队列内启动顺序（0 = 未显式排序，按 created_at 先来先启动）。
         self.add_column_if_missing("tasks", "queue_order", "INTEGER NOT NULL DEFAULT 0")
@@ -926,11 +957,13 @@ impl Db {
         Ok(())
     }
 
-    /// 更新任务状态与错误信息，并同步维护 `completed_at`（任务结束时间）：
+    /// 更新任务状态与错误信息，并同步维护 `completed_at`（任务结束时间）
+    /// 与 `file_present_at`（文件曾确证存在时刻，丢失文件清理资格证据）：
     /// - `status = 3`（下载完成）且尚未记录 → 写入当前 Unix 秒。此写入发生在
     ///   下载数据落盘完成之时，早于插件 onDone 等 hook 后处理，故结束时间
     ///   不含 hook 耗时；重复写 3（幂等竞态）不会覆盖首次记录。
-    /// - `status ∈ {0, 1, 5}`（重新排队/下载/准备）→ 清空，重下后重新记录。
+    /// - `status ∈ {0, 1, 5}`（重新排队/下载/准备）→ 清空 completed_at，
+    ///   重下后重新记录；`file_present_at` 是历史证据，不随重下清除。
     /// - 其余状态（暂停/错误）保持不变。
     pub async fn update_task_status(
         &self,
@@ -944,6 +977,10 @@ impl Db {
                      WHEN $1 = 3 AND completed_at = '' THEN $3
                      WHEN $1 IN (0, 1, 5) THEN ''
                      ELSE completed_at
+                 END,
+                 file_present_at = CASE
+                     WHEN $1 = 3 AND file_present_at = 0 THEN $5
+                     ELSE file_present_at
                  END
              WHERE id = $4",
         )
@@ -951,6 +988,7 @@ impl Db {
         .bind(error_message)
         .bind(chrono_now())
         .bind(id)
+        .bind(chrono_now_secs())
         .execute(&self.pool)
         .await?;
         Ok(())
@@ -981,10 +1019,12 @@ impl Db {
             return Ok(());
         }
         // SQLite has a max variable limit of 999; chunk to stay safe
-        // (same pattern as `load_tasks_by_ids`).  $1 = status, $2 = now.
+        // (same pattern as `load_tasks_by_ids`).
+        // $1 = status，$2 = completed_at 用 Unix 秒字符串，
+        // $3 = file_present_at 用 Unix 秒整数，id 从 $4 起。
         const CHUNK: usize = 500;
         for chunk in ids.chunks(CHUNK) {
-            let placeholders: String = (3..chunk.len() + 3)
+            let placeholders: String = (4..chunk.len() + 4)
                 .map(|i| format!("${i}"))
                 .collect::<Vec<_>>()
                 .join(",");
@@ -994,12 +1034,17 @@ impl Db {
                          WHEN $1 = 3 AND completed_at = '' THEN $2
                          WHEN $1 IN (0, 1, 5) THEN ''
                          ELSE completed_at
+                     END,
+                     file_present_at = CASE
+                         WHEN $1 = 3 AND file_present_at = 0 THEN $3
+                         ELSE file_present_at
                      END
                  WHERE id IN ({placeholders})"
             );
             let mut query = sqlx::query(AssertSqlSafe(sql))
                 .bind(status)
-                .bind(chrono_now());
+                .bind(chrono_now())
+                .bind(chrono_now_secs());
             for id in chunk {
                 query = query.bind(id.as_str());
             }
@@ -1032,6 +1077,43 @@ impl Db {
             .execute(&self.pool)
             .await?;
         Ok(result.rows_affected() > 0)
+    }
+
+    /// 丢失文件清理候选：已完成、文件确证丢失、且曾确证在最终路径存在过
+    /// （`downloaded_bytes > 0` 或完成时盖章 `file_present_at`）的任务。
+    /// 正在做种（`SEEDING_STATUS_ACTIVE`）/排队做种（`SEEDING_STATUS_QUEUED`）
+    /// 的任务被排除——它们仍被 librqbit 会话持有，须由用户显式删除
+    /// （走完整做种注销流程）。
+    ///
+    /// 「曾确证存在」守卫把「文件被用户删了」与「文件从未落盘」（0 字节
+    /// 任务、建文件前即失败的任务）区分开，后者永不被清理。
+    ///
+    /// [`Db::is_missing_cleanup_candidate`] 复用同一谓词常量
+    /// `MISSING_CLEANUP_WHERE`，确保批量预览与执行复核语义零漂移。
+    pub async fn load_missing_cleanup_candidates(&self) -> Result<Vec<TaskInfo>, DbError> {
+        let sql = format!(
+            "SELECT {TASK_COLUMNS} FROM tasks WHERE {MISSING_CLEANUP_WHERE} ORDER BY created_at DESC"
+        );
+        let rows = sqlx::query(AssertSqlSafe(sql))
+            .fetch_all(&self.pool)
+            .await?;
+        let mut tasks = Vec::with_capacity(rows.len());
+        for row in &rows {
+            tasks.push(task_from_row(row)?);
+        }
+        Ok(tasks)
+    }
+
+    /// 单任务资格复核：与 `load_missing_cleanup_candidates` 同一谓词。
+    /// 生产消费于 `DownloadManager::execute_missing_cleanup` 的执行前复核——
+    /// 状态/丢失标记/存在证据/做种态四维一次性判定，不手工复制谓词。
+    pub async fn is_missing_cleanup_candidate(&self, id: &str) -> Result<bool, DbError> {
+        let sql = format!("SELECT 1 FROM tasks WHERE id = $1 AND {MISSING_CLEANUP_WHERE}");
+        let row = sqlx::query(AssertSqlSafe(sql))
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await?;
+        Ok(row.is_some())
     }
 
     /// 更新任务完成时已上传字节数（BT 做种后分享率基准）。
@@ -1912,6 +1994,10 @@ impl Db {
             ("cdn_max_nodes", "0"),
             ("max_concurrent_tasks", "5"),
             ("speed_limit_bytes", "0"),
+            // 丢失文件自动清理："true" = 文件扫描完成后自动删除「已完成且
+            // 文件确证丢失且曾确证存在」的任务记录（资格谓词同
+            // MISSING_CLEANUP_WHERE）。默认关；实时读库，热生效。
+            ("auto_cleanup_missing_files", "false"),
             // 全局 BT 上传限速（B/s）："0" = 不限。与 speed_limit_bytes
             // 解耦：后者只管下载，本键管 BT 上传（下载期上传 + 做种）。
             ("upload_limit_bytes", "0"),
@@ -3706,11 +3792,15 @@ fn rss_item_from_row(row: &AnyRow) -> Result<RssItemInfo, sqlx::Error> {
 }
 
 fn chrono_now() -> String {
-    let now = std::time::SystemTime::now();
-    let since_epoch = now
+    format!("{}", chrono_now_secs())
+}
+
+/// Unix 秒（INTEGER 列专用；`chrono_now` 的 i64 版本，如 `file_present_at`）。
+fn chrono_now_secs() -> i64 {
+    std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default();
-    format!("{}", since_epoch.as_secs())
+        .unwrap_or_default()
+        .as_secs() as i64
 }
 
 // ---------------------------------------------------------------------------
@@ -5519,5 +5609,211 @@ mod tests {
         assert_eq!(y.queue_id, MAIN_QUEUE_ID);
         assert_eq!(y.queue_order, 0, "explicit order resets on reassignment");
         close_test_db(&db, dir).await;
+    }
+
+    // --------------------------------------------------------------------
+    // 丢失文件清理：资格谓词（MISSING_CLEANUP_WHERE）与 file_present_at 盖章
+    // --------------------------------------------------------------------
+
+    /// 按给定字段直接写入一行任务（谓词矩阵测试的搭建辅助）。
+    #[allow(clippy::too_many_arguments)]
+    async fn insert_cleanup_row(
+        db: &Db,
+        id: &str,
+        status: i32,
+        file_missing: bool,
+        downloaded_bytes: i64,
+        file_present_at: i64,
+        seeding_status: i32,
+    ) {
+        sqlx::query(
+            "INSERT INTO tasks (id, url, file_name, save_dir, status, \
+             total_bytes, downloaded_bytes, segments, created_at, file_missing, \
+             file_present_at, seeding_status) \
+             VALUES ($1, 'http://x', 'f', '/tmp', $2, 0, $3, 0, '0', $4, $5, $6)",
+        )
+        .bind(id)
+        .bind(status)
+        .bind(downloaded_bytes)
+        .bind(file_missing as i32)
+        .bind(file_present_at)
+        .bind(seeding_status)
+        .execute(&db.pool)
+        .await
+        .expect("insert cleanup row");
+    }
+
+    /// 谓词矩阵：每个资格维度单独违例都必须被排除；两条读路径
+    /// （批量候选 + 单任务复核）对同一行必须始终一致。
+    #[tokio::test]
+    async fn missing_cleanup_predicate_matrix() {
+        let db = Db::connect("sqlite::memory:")
+            .await
+            .expect("connect mem db");
+
+        // 合格：completed + 确证丢失 + 有下载字节证据。
+        insert_cleanup_row(&db, "ok-bytes", 3, true, 100, 0, 0).await;
+        // 合格：completed + 确证丢失 + 0 字节但有完成盖章证据。
+        insert_cleanup_row(&db, "ok-stamped", 3, true, 0, 1_700_000_000, 0).await;
+        // 排除：文件从未确证存在（0 字节且无盖章）——「从未落盘」≠「被删」。
+        insert_cleanup_row(&db, "no-evidence", 3, true, 0, 0, 0).await;
+        // 排除：文件未丢失。
+        insert_cleanup_row(&db, "not-missing", 3, false, 100, 0, 0).await;
+        // 排除：非 completed（paused）——谓词只管 status=3。
+        insert_cleanup_row(&db, "paused", 2, true, 100, 0, 0).await;
+        // 排除：做种中（SEEDING_STATUS_ACTIVE）——仍被 librqbit 会话持有。
+        insert_cleanup_row(&db, "seeding", 3, true, 100, 0, 1).await;
+        // 排除：排队做种（SEEDING_STATUS_QUEUED）。
+        insert_cleanup_row(&db, "seed-queued", 3, true, 100, 0, 8).await;
+
+        let candidates = db
+            .load_missing_cleanup_candidates()
+            .await
+            .expect("load candidates");
+        let mut ids: Vec<&str> = candidates.iter().map(|t| t.task_id.as_str()).collect();
+        ids.sort_unstable();
+        assert_eq!(
+            ids,
+            vec!["ok-bytes", "ok-stamped"],
+            "only fully-qualified tasks may be returned"
+        );
+
+        // 单任务复核路径必须与批量路径逐行一致。
+        for (id, expected) in [
+            ("ok-bytes", true),
+            ("ok-stamped", true),
+            ("no-evidence", false),
+            ("not-missing", false),
+            ("paused", false),
+            ("seeding", false),
+            ("seed-queued", false),
+        ] {
+            let got = db.is_missing_cleanup_candidate(id).await.expect("recheck");
+            assert_eq!(got, expected, "recheck mismatch for {id}");
+        }
+    }
+
+    /// file_present_at 生命周期：status→3 时盖章一次；重复写 3 不覆盖；
+    /// 重下（→0/1/5）清除 completed_at 但保留 file_present_at（历史证据）。
+    #[tokio::test]
+    async fn update_task_status_stamps_file_present_at_once() {
+        let db = Db::connect("sqlite::memory:")
+            .await
+            .expect("connect mem db");
+        insert_task(&db, "t1").await;
+
+        let present_at = || async {
+            sqlx::query_scalar::<_, i64>("SELECT file_present_at FROM tasks WHERE id = 't1'")
+                .fetch_one(&db.pool)
+                .await
+                .expect("read file_present_at")
+        };
+
+        assert_eq!(present_at().await, 0, "新任务不得有存在证据");
+
+        // 暂停/错误不盖章。
+        db.update_task_status("t1", 2, "").await.expect("pause");
+        db.update_task_status("t1", 4, "boom").await.expect("error");
+        assert_eq!(present_at().await, 0, "非完成状态不得盖章");
+
+        // 完成 → 盖章。
+        db.update_task_status("t1", 3, "").await.expect("complete");
+        let first = present_at().await;
+        assert!(first > 0, "完成时必须盖章");
+
+        // 重复写 3（幂等竞态）不覆盖首次记录。
+        db.update_task_status("t1", 3, "")
+            .await
+            .expect("re-complete");
+        assert_eq!(present_at().await, first, "重复完成不得覆盖首次盖章");
+
+        // 重下：completed_at 清空（既有契约），file_present_at 保留。
+        db.update_task_status("t1", 1, "")
+            .await
+            .expect("redownload");
+        assert_eq!(present_at().await, first, "重下不得清除历史证据");
+        let t = db
+            .load_task_by_id("t1")
+            .await
+            .expect("load")
+            .expect("present");
+        assert_eq!(t.completed_at, "", "重下必须清空 completed_at（既有契约）");
+
+        // 再次完成：已有盖章，不更新。
+        db.update_task_status("t1", 3, "")
+            .await
+            .expect("complete again");
+        assert_eq!(present_at().await, first, "已有盖章时再次完成不得更新");
+    }
+
+    /// 批量状态更新与单任务同一盖章契约。
+    #[tokio::test]
+    async fn update_tasks_status_batch_stamps_file_present_at() {
+        let db = Db::connect("sqlite::memory:")
+            .await
+            .expect("connect mem db");
+        insert_task(&db, "b1").await;
+        insert_task(&db, "b2").await;
+
+        db.update_tasks_status_batch(&["b1".to_string(), "b2".to_string()], 3)
+            .await
+            .expect("batch complete");
+
+        for id in ["b1", "b2"] {
+            let v = sqlx::query_scalar::<_, i64>("SELECT file_present_at FROM tasks WHERE id = $1")
+                .bind(id)
+                .fetch_one(&db.pool)
+                .await
+                .expect("read");
+            assert!(v > 0, "批量完成必须盖章（{id}）");
+        }
+
+        // 批量重下不清除历史证据。
+        db.update_tasks_status_batch(&["b1".to_string()], 0)
+            .await
+            .expect("batch requeue");
+        let v = sqlx::query_scalar::<_, i64>("SELECT file_present_at FROM tasks WHERE id = 'b1'")
+            .fetch_one(&db.pool)
+            .await
+            .expect("read");
+        assert!(v > 0, "批量重下不得清除历史证据");
+    }
+
+    /// 默认配置：`auto_cleanup_missing_files` 播种为 "false"（默认关闭，
+    /// 老库 ON CONFLICT DO NOTHING 不覆盖用户既有值）。
+    #[tokio::test]
+    async fn init_default_config_seeds_auto_cleanup_disabled() {
+        let db = Db::connect("sqlite::memory:")
+            .await
+            .expect("connect mem db");
+        db.init_default_config("/tmp").await.expect("seed defaults");
+        let v = db
+            .get_config("auto_cleanup_missing_files")
+            .await
+            .expect("get config")
+            .expect("seeded");
+        assert_eq!(v, "false", "自动清理必须默认关闭");
+
+        // 用户已开启时，重复播种不得覆盖。
+        db.set_config("auto_cleanup_missing_files", "true")
+            .await
+            .expect("user enable");
+        db.init_default_config("/tmp").await.expect("re-seed");
+        let v = db
+            .get_config("auto_cleanup_missing_files")
+            .await
+            .expect("get config")
+            .expect("seeded");
+        assert_eq!(v, "true", "重复播种不得覆盖用户设置");
+    }
+
+    /// MISSING_CLEANUP_WHERE 中的做种状态字面量必须与 bt_seeding 常量一致。
+    /// 若将来新增「数据仍被会话持有」的做种子状态，此测试会因谓词未更新而失败。
+    #[tokio::test]
+    async fn missing_cleanup_where_uses_bt_seeding_constants() {
+        use crate::bt_seeding::{SEEDING_STATUS_ACTIVE, SEEDING_STATUS_QUEUED};
+        assert_eq!(SEEDING_STATUS_ACTIVE, 1);
+        assert_eq!(SEEDING_STATUS_QUEUED, 8);
+        assert!(MISSING_CLEANUP_WHERE.contains("NOT IN (1, 8)"));
     }
 }

--- a/native/engine/src/download_manager.rs
+++ b/native/engine/src/download_manager.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, Mutex};
 
 use futures_util::FutureExt;
 use reqwest::Client;
-use tokio::sync::{Semaphore, mpsc, oneshot};
+use tokio::sync::{Notify, Semaphore, mpsc, oneshot};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
@@ -174,6 +174,17 @@ fn is_bt_url(url: &str) -> bool {
     is_magnet(url) || is_torrent_file_url(url)
 }
 
+/// BT staging 保底判定：staging 目录仍持有真实数据的任务视为「数据仍在」，
+/// 不参与丢失文件清理（哪怕最终路径已缺失）。覆盖「完成搬移部分失败」
+/// 场景——记录可删与否取决于数据是否真的没了，而不是最终路径是否存在。
+fn bt_staging_holds_data(t: &TaskInfo) -> bool {
+    is_bt_url(&t.url)
+        && bt_downloader::stage_dir_has_real_data(&bt_downloader::bt_stage_dir(
+            &t.save_dir,
+            &t.task_id,
+        ))
+}
+
 /// 文件跟踪扫描的并发上限。`try_exists` 内部走 tokio blocking 线程池，限流以
 /// bound 该共享池占用，防慢盘/网络盘扫描饿死并发下载 IO。
 const FILE_SCAN_CONCURRENCY: usize = 64;
@@ -181,6 +192,19 @@ const FILE_SCAN_CONCURRENCY: usize = 64;
 /// 单次文件存在性探测的超时（秒），防失联网络盘把整批扫描拖住到 OS 默认
 /// 重试时长。
 const FILE_SCAN_STAT_TIMEOUT_SECS: u64 = 5;
+
+/// 丢失文件清理 TOCTOU 复核的单次 stat 超时（秒）。手动/自动清理都跑在
+/// 用户等待路径上，不能像后台扫描那样给 5s 宽限——累积延迟会超出 Dart
+/// 端等待窗口（候选 35s / 执行 120s）。1s 足以区分本地盘上文件在与否，
+/// 网络盘慢则保守跳过（宁可漏删也不错删或让用户白等）。
+const CLEANUP_TOCTOU_TIMEOUT_SECS: u64 = 1;
+
+/// 丢失文件清理 BT staging 检查的单任务超时（秒）。staging 判定是同步递
+/// 归 `read_dir`（`spawn_blocking`），线程卡在死挂载/NFS 上时 JoinHandle
+/// 永不就绪——裸 await 会永久冻结调用方（actor 主循环）。阻塞池被既有
+/// 卡死线程耗尽后健康盘任务同样排不上线程，故必须包超时。超时按
+/// 「有数据」保守跳过（fail-safe）。
+const CLEANUP_STAGING_TIMEOUT_SECS: u64 = 5;
 
 /// 文件跟踪：构造 completed 任务的目标磁盘路径。`file_name` 为空或不安全
 /// （未命名 magnet、路径穿越等）时返回 `None`——无法可靠判定存在性，跳过。
@@ -213,19 +237,27 @@ async fn probe_missing(path: &Path) -> Option<bool> {
 /// [`DownloadManager::spawn_file_scan`] 在 detached task 中调用；`scanning`
 /// 标志确保同一时刻只有一个扫描在跑。双向判定（探到存在即把标志翻回 false），
 /// 无棘轮，文件移回后自愈。
-async fn scan_missing_files(db: Db, sink: Arc<dyn EventSink>, scanning: Arc<AtomicBool>) {
-    // 防重叠：已有扫描在跑就直接返回。
+async fn scan_missing_files(
+    db: Db,
+    sink: Arc<dyn EventSink>,
+    scanning: Arc<AtomicBool>,
+    scan_done: Arc<Notify>,
+) {
+    // 防重叠：已有扫描在跑就直接返回（在跑的那个收尾时会发完成通知）。
     if scanning.swap(true, Ordering::SeqCst) {
         return;
     }
-    // RAII 复位守卫：无论正常返回还是 panic 都把标志清回 false。
-    struct ScanGuard(Arc<AtomicBool>);
+    // RAII 复位守卫：无论正常返回还是 panic 都把标志清回 false，并发
+    // 「扫描完成」通知（`notify_one` 存一个许可，监听者暂未挂起也不丢），
+    // 宿主据此触发丢失文件自动清理——此刻 file_missing 标记最新。
+    struct ScanGuard(Arc<AtomicBool>, Arc<Notify>);
     impl Drop for ScanGuard {
         fn drop(&mut self) {
             self.0.store(false, Ordering::SeqCst);
+            self.1.notify_one();
         }
     }
-    let _guard = ScanGuard(scanning);
+    let _guard = ScanGuard(scanning, scan_done);
 
     let tasks = match db.load_all_tasks().await {
         Ok(t) => t,
@@ -1296,6 +1328,8 @@ pub struct DownloadManager {
     /// 文件跟踪扫描是否正在进行（防重叠）。内存级；`Arc` 以便 detached 扫描
     /// task 与调用方共享同一标志。
     scanning: Arc<AtomicBool>,
+    /// 文件扫描完成通知（扫描收尾 RAII 守卫触发；供宿主驱动丢失文件自动清理）。
+    scan_done: Arc<Notify>,
     /// Boost 模式当前优先任务 ID（内存级，重启清空）。None = 无优先任务。
     priority_task_id: Option<String>,
     /// 因 Boost 模式自动暂停的任务 ID 集合（内存级，重启清空）。
@@ -1390,6 +1424,21 @@ pub struct DownloadManagerConfig {
     pub proxy_config: ProxyConfig,
     pub user_agent: String,
 }
+
+/// 执行丢失文件清理的返回：`deleted` 已硬删除数，`healed` TOCTOU
+/// 复核发现文件仍存在时回收 `file_missing=false` 的自愈数。调用方
+/// 应在任一 > 0 时刷新 UI，避免「全自愈」场景下 UI 仍显示过期标记。
+#[derive(Debug, Default)]
+pub struct CleanupOutcome {
+    pub deleted: usize,
+    pub healed: usize,
+}
+
+impl CleanupOutcome {
+    pub fn had_effect(&self) -> bool {
+        self.deleted > 0 || self.healed > 0
+    }
+}
 impl DownloadManager {
     pub fn new(
         db: Db,
@@ -1457,6 +1506,7 @@ impl DownloadManager {
             startup_reset_done: false,
             suppress_bulk_broadcasts: false,
             scanning: Arc::new(AtomicBool::new(false)),
+            scan_done: Arc::new(Notify::new()),
             priority_task_id: None,
             auto_paused_ids: HashSet::new(),
             auto_retry_counts: HashMap::new(),
@@ -3681,9 +3731,17 @@ impl DownloadManager {
         let db = self.db.clone();
         let sink = self.sink.clone();
         let scanning = self.scanning.clone();
+        let scan_done = self.scan_done.clone();
         tokio::spawn(async move {
-            scan_missing_files(db, sink, scanning).await;
+            scan_missing_files(db, sink, scanning, scan_done).await;
         });
+    }
+
+    /// 「文件扫描完成」通知句柄：每次扫描收尾（含提前返回/panic，经 RAII
+    /// 守卫）触发一次。宿主监听它驱动丢失文件自动清理——此时
+    /// `file_missing` 标记刚刷新，是清理决策的最新依据。
+    pub fn scan_done_notify(&self) -> Arc<Notify> {
+        self.scan_done.clone()
     }
 
     /// Normalize seeding state left over from a previous session.
@@ -6219,6 +6277,202 @@ impl DownloadManager {
         // A slot freed up — try to start queued tasks.
         self.drain_queue().await;
         self.maybe_release_bt_session().await;
+    }
+
+    /// 「文件已丢失」清理候选（只读预览）。
+    ///
+    /// 资格 = [`crate::db::Db::load_missing_cleanup_candidates`] 的 SQL 谓词
+    /// （completed + 确证丢失 + 曾确证有文件 + 非做种/排队做种），再叠加
+    /// BT staging 保底：staging 目录仍持有真实数据的任务（完成搬移部分
+    /// 失败等）哪怕最终路径缺失也不进候选——记录可删与否取决于数据是否
+    /// 真的没了，而不是最终路径是否存在。查询失败降级为空清单（预览
+    /// 场景下宁可显示「无可清理」也不可报错打断用户）。
+    ///
+    /// 注意：本函数在调用方（actor）轮次内同步 await——DB 查询 + BT
+    /// staging 收集（30s 总包超时封顶）。慢盘上会让 actor 停转数秒，
+    /// 这是有意的折衷：清理决策必须与任务生命周期串行，off-actor 并发
+    /// 执行会引入「删除 vs 任务操作」竞态。
+    pub async fn missing_cleanup_candidates(&self) -> Vec<TaskInfo> {
+        let tasks = match self.db.load_missing_cleanup_candidates().await {
+            Ok(t) => t,
+            Err(e) => {
+                log_info!("[missing-cleanup] load candidates error: {}", e);
+                return Vec::new();
+            }
+        };
+        if tasks.is_empty() {
+            return Vec::new();
+        }
+        // BT staging 判定是同步递归 read_dir：逐任务 spawn_blocking +
+        // Semaphore 限流（与文件扫描共用并发上限，防慢盘扫描饿死下载 IO）。
+        // 整个收集包 30s 总包超时——死挂载上 blocking 线程永不就绪时宁可
+        // 返回空预览，也不让调用方无限等待。
+        let sem = Arc::new(Semaphore::new(FILE_SCAN_CONCURRENCY));
+        let collect = async move {
+            let mut candidates: Vec<Option<TaskInfo>> = Vec::with_capacity(tasks.len());
+            let mut bt_handles: Vec<(usize, JoinHandle<bool>)> = Vec::new();
+            for t in tasks {
+                let idx = candidates.len();
+                // BT 任务默认保守排除，唯有 staging 检查确证无数据才放行；
+                // 许可获取失败（semaphore 关闭，实际不可达）同样排除。
+                if !is_bt_url(&t.url) {
+                    candidates.push(Some(t));
+                    continue;
+                }
+                match sem.clone().acquire_owned().await {
+                    Ok(permit) => {
+                        let probe = t.clone();
+                        bt_handles.push((
+                            idx,
+                            tokio::task::spawn_blocking(move || {
+                                let _permit = permit;
+                                bt_staging_holds_data(&probe)
+                            }),
+                        ));
+                        candidates.push(Some(t));
+                    }
+                    Err(_) => candidates.push(None),
+                }
+            }
+            for (slot, handle) in bt_handles {
+                // spawn_blocking panic 按「有数据」保守排除。
+                if handle.await.unwrap_or(true) {
+                    candidates[slot] = None;
+                }
+            }
+            candidates.into_iter().flatten().collect::<Vec<_>>()
+        };
+        match tokio::time::timeout(std::time::Duration::from_secs(30), collect).await {
+            Ok(v) => v,
+            Err(_) => {
+                log_info!("[missing-cleanup] BT staging collection timed out after 30s");
+                Vec::new()
+            }
+        }
+    }
+
+    /// 执行丢失文件清理：对每个 id 先经 `is_missing_cleanup_candidate`
+    /// 资格复核（与候选查询同一谓词，状态/丢失标记/存在证据/做种态四维
+    /// 零漂移），再做 TOCTOU 实时 stat（文件找回则自愈标记并计入 healed），
+    /// BT 任务额外过 staging 保底，全部通过才经 `delete_task` 完整生命周期
+    /// 删除。返回 [`CleanupOutcome`]，调用方据 `had_effect()` 决定刷新 UI。
+    pub async fn execute_missing_cleanup(&mut self, task_ids: &[String]) -> CleanupOutcome {
+        let mut deleted = 0usize;
+        let mut healed = 0usize;
+        for id in task_ids {
+            // 资格复核走与候选查询同一谓词——覆盖存在证据维度
+            // （「从未落盘」≠「被删」），调用方绕过候选列表直塞 id 也安全。
+            match self.db.is_missing_cleanup_candidate(id).await {
+                Ok(true) => {}
+                Ok(false) => continue,
+                Err(e) => {
+                    log_info!("[missing-cleanup] recheck {} error: {}", id, e);
+                    continue;
+                }
+            }
+            let t = match self.db.load_task_by_id(id).await {
+                Ok(Some(t)) => t,
+                Ok(None) => continue,
+                Err(e) => {
+                    log_info!("[missing-cleanup] reload {} error: {}", id, e);
+                    continue;
+                }
+            };
+            // TOCTOU：DB 的 file_missing 标记可能过期（文件从回收站找回）。
+            // 实时 stat 确认仍缺失才放行；stat 超时/错误一律保守跳过。
+            if let Some(path) = task_target_path(&t.save_dir, &t.file_name) {
+                match tokio::time::timeout(
+                    std::time::Duration::from_secs(CLEANUP_TOCTOU_TIMEOUT_SECS),
+                    tokio::fs::try_exists(&path),
+                )
+                .await
+                {
+                    Ok(Ok(true)) => {
+                        let _ = self.db.update_task_file_missing(id, false).await;
+                        healed += 1;
+                        continue;
+                    }
+                    Err(_) | Ok(Err(_)) => {
+                        log_info!("[missing-cleanup] stat timeout for {}, skipping", id);
+                        continue;
+                    }
+                    Ok(Ok(false)) => { /* 确认缺失，放行 */ }
+                }
+            }
+            // BT staging 保底：必须包超时——死挂载/阻塞池耗尽会让
+            // JoinHandle 永不就绪，裸 await 会永久冻结 actor 主循环。
+            // 超时按「有数据」保守跳过（fail-safe）。
+            if is_bt_url(&t.url) {
+                let staged = match tokio::time::timeout(
+                    std::time::Duration::from_secs(CLEANUP_STAGING_TIMEOUT_SECS),
+                    tokio::task::spawn_blocking(move || bt_staging_holds_data(&t)),
+                )
+                .await
+                {
+                    Ok(join) => join.unwrap_or(true),
+                    Err(_) => {
+                        log_info!(
+                            "[missing-cleanup] staging check timeout for {}, skipping",
+                            id
+                        );
+                        continue;
+                    }
+                };
+                if staged {
+                    continue;
+                }
+            }
+            self.delete_task(id, false).await;
+            // 删除确认走三路 match（Ok(None) 才计数），不靠 rows_affected。
+            match self.db.load_task_by_id(id).await {
+                Ok(None) => deleted += 1,
+                Ok(Some(_)) | Err(_) => {
+                    log_info!(
+                        "[missing-cleanup] DB delete unconfirmed for {}, skipping count",
+                        id
+                    );
+                    continue;
+                }
+            }
+        }
+        if deleted > 0 {
+            log_info!(
+                "[missing-cleanup] removed {} tasks with missing files",
+                deleted
+            );
+        }
+        if healed > 0 {
+            log_info!(
+                "[missing-cleanup] healed {} tasks (file re-appeared)",
+                healed
+            );
+        }
+        CleanupOutcome { deleted, healed }
+    }
+
+    /// 自动清理入口（设置项 `auto_cleanup_missing_files` 开启时由宿主在
+    /// 文件扫描完成后触发，见 [`Self::scan_done_notify`]）：候选取全量
+    /// 资格集，执行路径与手动确认完全一致。开关实时读库，热生效；
+    /// 默认关闭。
+    pub async fn auto_cleanup_missing_files(&mut self) -> CleanupOutcome {
+        let enabled = self
+            .db
+            .get_config("auto_cleanup_missing_files")
+            .await
+            .ok()
+            .flatten()
+            .map(|v| v == "true")
+            .unwrap_or(false);
+        if !enabled {
+            return CleanupOutcome::default();
+        }
+        let ids: Vec<String> = self
+            .missing_cleanup_candidates()
+            .await
+            .into_iter()
+            .map(|t| t.task_id)
+            .collect();
+        self.execute_missing_cleanup(&ids).await
     }
 
     /// Delete task record and optionally its files on disk.
@@ -9640,7 +9894,13 @@ mod tests {
         let sink = Arc::new(RecordingSink::new());
 
         // (a) 文件仍在：不落库变化、不发事件。
-        scan_missing_files(db.clone(), sink.clone(), Arc::new(AtomicBool::new(false))).await;
+        scan_missing_files(
+            db.clone(),
+            sink.clone(),
+            Arc::new(AtomicBool::new(false)),
+            Arc::new(Notify::new()),
+        )
+        .await;
         let task = db
             .load_task_by_id("t-roundtrip")
             .await
@@ -9657,7 +9917,13 @@ mod tests {
 
         // (b) 文件被删：翻为 true，发一次事件。
         std::fs::remove_file(&file_path).expect("delete test file");
-        scan_missing_files(db.clone(), sink.clone(), Arc::new(AtomicBool::new(false))).await;
+        scan_missing_files(
+            db.clone(),
+            sink.clone(),
+            Arc::new(AtomicBool::new(false)),
+            Arc::new(Notify::new()),
+        )
+        .await;
         let task = db
             .load_task_by_id("t-roundtrip")
             .await
@@ -9683,7 +9949,13 @@ mod tests {
 
         // (c) 文件移回：翻回 false，再发一次事件（双向自愈，无棘轮）。
         std::fs::write(&file_path, b"data").expect("recreate test file");
-        scan_missing_files(db.clone(), sink.clone(), Arc::new(AtomicBool::new(false))).await;
+        scan_missing_files(
+            db.clone(),
+            sink.clone(),
+            Arc::new(AtomicBool::new(false)),
+            Arc::new(Notify::new()),
+        )
+        .await;
         let task = db
             .load_task_by_id("t-roundtrip")
             .await
@@ -9725,7 +9997,13 @@ mod tests {
         insert_task_at_status(&db, "t-downloading", &save_dir, "movie.mp4", 1).await;
 
         let sink = Arc::new(RecordingSink::new());
-        scan_missing_files(db.clone(), sink.clone(), Arc::new(AtomicBool::new(false))).await;
+        scan_missing_files(
+            db.clone(),
+            sink.clone(),
+            Arc::new(AtomicBool::new(false)),
+            Arc::new(Notify::new()),
+        )
+        .await;
 
         let task = db
             .load_task_by_id("t-downloading")
@@ -9759,7 +10037,13 @@ mod tests {
         insert_task_at_status(&db, "t-active-redownload", &save_dir, file_name, 1).await;
 
         let sink = Arc::new(RecordingSink::new());
-        scan_missing_files(db.clone(), sink.clone(), Arc::new(AtomicBool::new(false))).await;
+        scan_missing_files(
+            db.clone(),
+            sink.clone(),
+            Arc::new(AtomicBool::new(false)),
+            Arc::new(Notify::new()),
+        )
+        .await;
 
         let completed = db
             .load_task_by_id("t-completed-stale")
@@ -9997,5 +10281,280 @@ mod tests {
             vec![("q".to_string(), false)],
             "start == stop resolves to stop"
         );
+    }
+
+    // --------------------------------------------------------------------
+    // 丢失文件清理：BT staging 保底 / TOCTOU 复核 / 自动清理开关 / 降级
+    // --------------------------------------------------------------------
+
+    /// 构造清理测试用的 DownloadManager（内存库 + 录音 sink）。
+    fn cleanup_test_manager(db: Db, save_dir: &str) -> DownloadManager {
+        DownloadManager::new(
+            db,
+            DownloadManagerConfig {
+                max_concurrent: 1,
+                speed_limit_bps: 0,
+                upload_limit_bps: 0,
+                default_save_dir: save_dir.to_string(),
+                app_data_dir: String::new(),
+                data_dir: std::env::temp_dir(),
+                bt_config: BtConfig::default(),
+                proxy_config: ProxyConfig::default(),
+                user_agent: String::new(),
+            },
+            Arc::new(RecordingSink::new()),
+            Arc::new(crate::NoopSelection),
+        )
+        .expect("construct manager")
+    }
+
+    /// 搭建：插入任务并置为 completed（完成时盖章 file_present_at）
+    /// + 文件确证丢失。
+    async fn insert_completed_missing(
+        db: &Db,
+        id: &str,
+        url: &str,
+        file_name: &str,
+        save_dir: &str,
+    ) {
+        db.insert_task(id, url, file_name, save_dir, 1, 0, "", "", "", 0)
+            .await
+            .expect("insert");
+        db.update_task_status(id, 3, "").await.expect("complete");
+        db.update_task_file_missing(id, true)
+            .await
+            .expect("mark missing");
+    }
+
+    /// `execute_missing_cleanup` 对 BT 任务的保底复核：staging 目录仍持有
+    /// 真实数据（完成搬移部分失败）时任务不能被删除。
+    #[tokio::test]
+    async fn execute_missing_cleanup_skips_bt_with_staging_data() {
+        let dir = unique_filetrack_test_dir("bt_staging_guard");
+        std::fs::create_dir_all(&dir).expect("create test dir");
+        let save_dir = dir.to_string_lossy().to_string();
+
+        let db = Db::connect("sqlite::memory:").await.expect("connect");
+        // BT 判定依赖 magnet URL；已完成 + 文件确证丢失。
+        insert_completed_missing(
+            &db,
+            "t-bt-staging",
+            "magnet:?xt=urn:btih:aaaa",
+            "movie.mp4",
+            &save_dir,
+        )
+        .await;
+
+        // 构造 staging 目录含真实数据：模拟「搬移部分失败」场景。
+        let stage_dir = dir.join(".bt_stage_t-bt-staging");
+        std::fs::create_dir_all(&stage_dir).expect("create stage dir");
+        std::fs::write(stage_dir.join("part.bin"), b"real-data").expect("write stage file");
+
+        let mut mgr = cleanup_test_manager(db.clone(), &save_dir);
+        let outcome = mgr
+            .execute_missing_cleanup(&["t-bt-staging".to_string()])
+            .await;
+        assert_eq!(
+            outcome.deleted, 0,
+            "BT task with staging data must be skipped"
+        );
+        assert!(
+            db.load_task_by_id("t-bt-staging")
+                .await
+                .expect("load")
+                .is_some(),
+            "skipped task must survive"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// TOCTOU 磁盘复核：文件从回收站找回后仍存在磁盘上 → 不删除，
+    /// 并自愈回收 file_missing 标记为 false。
+    #[tokio::test]
+    async fn execute_missing_cleanup_toctou_skips_if_file_recovered() {
+        let dir = unique_filetrack_test_dir("toctou_recovered");
+        std::fs::create_dir_all(&dir).expect("create test dir");
+        let save_dir = dir.to_string_lossy().to_string();
+        let file_path = dir.join("real.mp4");
+        std::fs::write(&file_path, b"hello").expect("write file");
+
+        let db = Db::connect("sqlite::memory:").await.expect("connect");
+        insert_completed_missing(
+            &db,
+            "t-recovered",
+            "https://example.com/real.mp4",
+            "real.mp4",
+            &save_dir,
+        )
+        .await;
+
+        let mut mgr = cleanup_test_manager(db.clone(), &save_dir);
+        let outcome = mgr
+            .execute_missing_cleanup(&["t-recovered".to_string()])
+            .await;
+        assert_eq!(outcome.deleted, 0, "file exists on disk -> must NOT delete");
+        assert!(outcome.healed > 0, "TOCTOU should self-heal file_missing");
+
+        let t = db
+            .load_task_by_id("t-recovered")
+            .await
+            .expect("load")
+            .expect("exist");
+        assert!(!t.file_missing, "file_missing should be reset to false");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// 存在证据纵深防御：即便调用方把「0 字节且从未盖章」的任务 id 直接
+    /// 塞进执行清单（绕过候选谓词），执行前的资格复核也必须拒绝删除——
+    /// 「文件从未落盘」≠「被用户删除」。
+    #[tokio::test]
+    async fn execute_missing_cleanup_skips_task_without_existence_evidence() {
+        let dir = unique_filetrack_test_dir("no_evidence");
+        std::fs::create_dir_all(&dir).expect("create test dir");
+        let save_dir = dir.to_string_lossy().to_string();
+
+        let db = Db::connect("sqlite::memory:").await.expect("connect");
+        // 直写行绕过盖章逻辑：completed + 确证丢失，但 0 字节且无完成盖章。
+        sqlx::query(
+            "INSERT INTO tasks (id, url, file_name, save_dir, status, \
+             total_bytes, downloaded_bytes, segments, created_at, file_missing, \
+             file_present_at) \
+             VALUES ('t-no-evidence', 'https://example.com/gone.bin', 'gone.bin', \
+             $1, 3, 0, 0, 0, '0', 1, 0)",
+        )
+        .bind(&save_dir)
+        .execute(db.test_pool())
+        .await
+        .expect("insert no-evidence row");
+
+        let mut mgr = cleanup_test_manager(db.clone(), &save_dir);
+        let outcome = mgr
+            .execute_missing_cleanup(&["t-no-evidence".to_string()])
+            .await;
+        assert_eq!(
+            outcome.deleted, 0,
+            "task without existence evidence must survive"
+        );
+        assert!(
+            db.load_task_by_id("t-no-evidence")
+                .await
+                .expect("load")
+                .is_some()
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// `missing_cleanup_candidates` 的编排层回归：BT staging 有数据时
+    /// 排除该 BT 任务，非 BT 任务（HTTP）正常保留在候选集中。
+    #[tokio::test]
+    async fn missing_cleanup_candidates_filters_bt_with_staging_data() {
+        let dir = unique_filetrack_test_dir("candidates_bt");
+        std::fs::create_dir_all(&dir).expect("create test dir");
+        let save_dir = dir.to_string_lossy().to_string();
+
+        let db = Db::connect("sqlite::memory:").await.expect("connect");
+        // BT 任务（magnet）：staging 有数据 → 应从候选集中排除。
+        insert_completed_missing(
+            &db,
+            "t-bt",
+            "magnet:?xt=urn:btih:bbbb",
+            "bt-movie.mp4",
+            &save_dir,
+        )
+        .await;
+        let stage_dir = dir.join(".bt_stage_t-bt");
+        std::fs::create_dir_all(&stage_dir).expect("create stage dir");
+        std::fs::write(stage_dir.join("part.bin"), b"x").expect("write stage file");
+
+        // 非 BT 任务（HTTP）：应正常出现在候选集中。
+        insert_completed_missing(
+            &db,
+            "t-http",
+            "https://example.com/file.zip",
+            "file.zip",
+            &save_dir,
+        )
+        .await;
+
+        let mgr = cleanup_test_manager(db.clone(), &save_dir);
+        let candidates = mgr.missing_cleanup_candidates().await;
+        let ids: Vec<&str> = candidates.iter().map(|t| t.task_id.as_str()).collect();
+        assert!(
+            !ids.contains(&"t-bt"),
+            "BT with staging data must be excluded"
+        );
+        assert!(ids.contains(&"t-http"), "HTTP task must be included");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// 候选查询 DB 故障降级：查询失败必须返回空清单（预览宁可显示
+    /// 「无可清理」也不报错打断用户），绝不 panic 或上抛。
+    #[tokio::test]
+    async fn missing_cleanup_candidates_degrades_to_empty_on_db_error() {
+        let db = Db::connect("sqlite::memory:").await.expect("connect");
+        sqlx::query("DROP TABLE tasks")
+            .execute(db.test_pool())
+            .await
+            .expect("drop tasks");
+        let mgr = cleanup_test_manager(db.clone(), "/tmp");
+        let candidates = mgr.missing_cleanup_candidates().await;
+        assert!(
+            candidates.is_empty(),
+            "DB error must degrade to empty candidate list"
+        );
+    }
+
+    /// `auto_cleanup_missing_files` 入口契约：开关关闭返回 0（安全默认），
+    /// 开启则执行实际清理并返回删除数。
+    #[tokio::test]
+    async fn auto_cleanup_missing_files_respects_config_switch() {
+        let dir = unique_filetrack_test_dir("auto_cleanup_switch");
+        std::fs::create_dir_all(&dir).expect("create test dir");
+        let save_dir = dir.to_string_lossy().to_string();
+
+        let db = Db::connect("sqlite::memory:").await.expect("connect");
+        insert_completed_missing(
+            &db,
+            "t-http-switch",
+            "https://example.com/file.bin",
+            "file.bin",
+            &save_dir,
+        )
+        .await;
+
+        let mut mgr = cleanup_test_manager(db.clone(), &save_dir);
+        // 默认关闭。
+        let outcome_off = mgr.auto_cleanup_missing_files().await;
+        assert_eq!(outcome_off.deleted, 0, "默认关闭时不得删除任何任务");
+        assert!(
+            db.load_task_by_id("t-http-switch")
+                .await
+                .expect("load")
+                .is_some()
+        );
+
+        // 开启后应执行清理。
+        db.set_config("auto_cleanup_missing_files", "true")
+            .await
+            .expect("set config");
+        let outcome_on = mgr.auto_cleanup_missing_files().await;
+        assert!(
+            outcome_on.deleted > 0,
+            "expected >0, got {}",
+            outcome_on.deleted
+        );
+        assert!(
+            db.load_task_by_id("t-http-switch")
+                .await
+                .expect("load")
+                .is_none(),
+            "开启后合格任务应被删除"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/native/hub/src/actors/download_actor.rs
+++ b/native/hub/src/actors/download_actor.rs
@@ -29,20 +29,21 @@ use crate::signals::{
     BatchControlTask, BatchCreateTask, CheckFileAssociation, CheckForUpdate, CheckUrlProtocol,
     ClearWebhookDeliveries, ConfigEntry, ConfigLoaded, ConfirmExternalDownload, ControlTask,
     CreateQueue, CreateRssSource, CreateTask, CreateTaskGroup, DeleteQueue, DeleteRssSource,
-    DetectSystemProxy, DownloadUpdate, Ed2kServerSubscriptionResult, ExternalDownloadRequest,
-    FfmpegInstallProgress, FfmpegInstallResult, FfmpegStatusReport, FfmpegVersionList,
-    FileAssociationStatus, GroupControl, IgnorePluginRetry, InstallFfmpeg, InstallMarketPlugin,
-    InstallPlugin, InstallUpdate, InstallYtdlp, MoveTaskToQueue, OpenFile, ProbeTorrentMeta,
-    ProxyTestResult, RefreshRssSource, RenameGroup, RenameTask, RenameTaskResult,
-    ReorderQueueTasks, RequestAllGroups, RequestAllQueues, RequestAllRssSources, RequestAllTasks,
-    RequestConfig, RequestFfmpegStatus, RequestFfmpegVersions, RequestMarketIndex, RequestPlugins,
-    RequestRssItems, RequestUpdateFailureMarker, RequestWebhookDeliveries, RequestYtdlpStatus,
-    RequestYtdlpVersions, RescanFiles, ResolvePreviewRequest, RevealFile, SaveConfig,
-    SavePluginSettings, SelectBtFiles, SelectHlsQuality, SelectResolveVariant, SetFileAssociation,
-    SetPluginEnabled, SetPriorityTask, SetQueueSchedule, SetRssItemAction, SetTaskSeedLimits,
-    SetUrlProtocol, SimulateWebhookEvent, StartQueue, StopQueue, SystemProxyInfo,
-    TaskSegmentsUpdated, TestProxyConnection, TestWebhookEndpoint, TrackerSubscriptionResult,
-    UninstallFfmpeg, UninstallPlugin, UninstallYtdlp, UpdateCheckResult,
+    DetectSystemProxy, DownloadUpdate, Ed2kServerSubscriptionResult, ExecuteMissingCleanup,
+    ExternalDownloadRequest, FfmpegInstallProgress, FfmpegInstallResult, FfmpegStatusReport,
+    FfmpegVersionList, FileAssociationStatus, GetMissingCleanupCandidates, GroupControl,
+    IgnorePluginRetry, InstallFfmpeg, InstallMarketPlugin, InstallPlugin, InstallUpdate,
+    InstallYtdlp, MissingCleanupCandidatesResult, MissingCleanupExecuted, MoveTaskToQueue,
+    OpenFile, ProbeTorrentMeta, ProxyTestResult, RefreshRssSource, RenameGroup, RenameTask,
+    RenameTaskResult, ReorderQueueTasks, RequestAllGroups, RequestAllQueues, RequestAllRssSources,
+    RequestAllTasks, RequestConfig, RequestFfmpegStatus, RequestFfmpegVersions, RequestMarketIndex,
+    RequestPlugins, RequestRssItems, RequestUpdateFailureMarker, RequestWebhookDeliveries,
+    RequestYtdlpStatus, RequestYtdlpVersions, RescanFiles, ResolvePreviewRequest, RevealFile,
+    SaveConfig, SavePluginSettings, SelectBtFiles, SelectHlsQuality, SelectResolveVariant,
+    SetFileAssociation, SetPluginEnabled, SetPriorityTask, SetQueueSchedule, SetRssItemAction,
+    SetTaskSeedLimits, SetUrlProtocol, SimulateWebhookEvent, StartQueue, StopQueue,
+    SystemProxyInfo, TaskSegmentsUpdated, TestProxyConnection, TestWebhookEndpoint,
+    TrackerSubscriptionResult, UninstallFfmpeg, UninstallPlugin, UninstallYtdlp, UpdateCheckResult,
     UpdateEd2kServerSubscription, UpdateFailureMarker, UpdateQueue, UpdateRssSource,
     UpdateTaskSegments, UpdateTrackerSubscription, UrlProtocolStatus, ValidateRssFeed,
     WebhookDeliveries, WebhookPresets, WebhookSimulateAck, WebhookTestResult, YtdlpInstallProgress,
@@ -341,6 +342,17 @@ async fn load_initial_config(
         cdn_multi_enabled,
         cdn_max_nodes,
     )
+}
+
+/// 提取 `catch_unwind` 载荷的可读消息（String / &str / 未知类型兜底）。
+fn panic_payload_message(e: Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = e.downcast_ref::<String>() {
+        s.clone()
+    } else if let Some(s) = e.downcast_ref::<&str>() {
+        (*s).to_string()
+    } else {
+        "unknown panic".to_string()
+    }
 }
 
 pub async fn run(db_dir: PathBuf) {
@@ -996,12 +1008,19 @@ pub async fn run(db_dir: PathBuf) {
         Simulate(SimulateWebhookEvent),
         Test(TestWebhookEndpoint),
     }
+    enum CleanupSignal {
+        RequestCandidates(GetMissingCleanupCandidates),
+        Execute(ExecuteMissingCleanup),
+    }
     enum AuxSignal {
         Group(GroupSignal),
         Rss(RssSignal),
         Webhook(WebhookSignal),
+        Cleanup(CleanupSignal),
         /// BT 做种限制求值节拍（`SEEDING_EVAL_INTERVAL`，见 engine::bt_seeding）。
         SeedingTick,
+        /// 文件扫描完成 → 触发丢失文件自动清理（若设置开启）。
+        CleanupTick,
         /// 任务级做种限制覆盖写入（热读，下一次做种求值 tick 生效）。
         SeedLimits(SetTaskSeedLimits),
     }
@@ -1066,6 +1085,36 @@ pub async fn run(db_dir: PathBuf) {
             }
         });
     }
+
+    let cleanup_tx = aux_tx.clone();
+    {
+        let request_candidates_recv = GetMissingCleanupCandidates::get_dart_signal_receiver();
+        let execute_cleanup_recv = ExecuteMissingCleanup::get_dart_signal_receiver();
+        tokio::spawn(async move {
+            loop {
+                let sent = tokio::select! {
+                    Some(s) = request_candidates_recv.recv() => cleanup_tx.send(AuxSignal::Cleanup(CleanupSignal::RequestCandidates(s.message))),
+                    Some(s) = execute_cleanup_recv.recv() => cleanup_tx.send(AuxSignal::Cleanup(CleanupSignal::Execute(s.message))),
+                    else => break,
+                };
+                if sent.is_err() {
+                    break;
+                }
+            }
+        });
+    }
+
+    // 文件扫描完成 → 丢入 aux 泵触发丢失文件自动清理（若设置开启）。
+    let cleanup_scan_done = engine.manager.scan_done_notify();
+    let cleanup_tick_tx = aux_tx.clone();
+    tokio::spawn(async move {
+        loop {
+            cleanup_scan_done.notified().await;
+            if cleanup_tick_tx.send(AuxSignal::CleanupTick).is_err() {
+                break; // actor 已退出
+            }
+        }
+    });
 
     let rss_tx = aux_tx;
     {
@@ -1470,6 +1519,83 @@ pub async fn run(db_dir: PathBuf) {
                 },
                 AuxSignal::SeedingTick => {
                     engine.manager.tick_seeding_evaluation().await;
+                }
+                AuxSignal::Cleanup(cleanup_signal) => match cleanup_signal {
+                    CleanupSignal::RequestCandidates(msg) => {
+                        // panic 不扩散：预览失败按空清单应答（Dart 显示
+                        // 「无可清理」），绝不杀死 actor 主循环。
+                        let candidates = match futures_util::FutureExt::catch_unwind(
+                            std::panic::AssertUnwindSafe(
+                                engine.manager.missing_cleanup_candidates(),
+                            ),
+                        )
+                        .await
+                        {
+                            Ok(c) => c,
+                            Err(e) => {
+                                log_info!(
+                                    "[missing-cleanup] candidates panicked: {}",
+                                    panic_payload_message(e)
+                                );
+                                Vec::new()
+                            }
+                        };
+                        let candidates: Vec<crate::signals::TaskInfo> =
+                            candidates.into_iter().map(|t| t.into()).collect();
+                        MissingCleanupCandidatesResult {
+                            request_id: msg.request_id,
+                            candidates,
+                        }
+                        .send_signal_to_dart();
+                    }
+                    CleanupSignal::Execute(msg) => {
+                        let outcome = match futures_util::FutureExt::catch_unwind(
+                            std::panic::AssertUnwindSafe(
+                                engine.manager.execute_missing_cleanup(&msg.task_ids),
+                            ),
+                        )
+                        .await
+                        {
+                            Ok(o) => o,
+                            Err(e) => {
+                                log_info!(
+                                    "[missing-cleanup] execute panicked: {}",
+                                    panic_payload_message(e)
+                                );
+                                Default::default()
+                            }
+                        };
+                        if outcome.had_effect() {
+                            engine.manager.load_and_send_all_tasks().await;
+                        }
+                        MissingCleanupExecuted {
+                            request_id: msg.request_id,
+                            deleted: i32::try_from(outcome.deleted).unwrap_or(i32::MAX),
+                            healed: i32::try_from(outcome.healed).unwrap_or(i32::MAX),
+                        }
+                        .send_signal_to_dart();
+                    }
+                },
+                AuxSignal::CleanupTick => {
+                    let outcome = match futures_util::FutureExt::catch_unwind(
+                        std::panic::AssertUnwindSafe(
+                            engine.manager.auto_cleanup_missing_files(),
+                        ),
+                    )
+                    .await
+                    {
+                        Ok(o) => o,
+                        Err(e) => {
+                            log_info!(
+                                "[missing-cleanup] auto (tick) panicked: {}",
+                                panic_payload_message(e)
+                            );
+                            Default::default()
+                        }
+                    };
+                    if outcome.had_effect() {
+                        engine.manager.load_and_send_all_tasks().await;
+                    }
                 }
                 AuxSignal::SeedLimits(msg) => {
                     engine

--- a/native/hub/src/signals/mod.rs
+++ b/native/hub/src/signals/mod.rs
@@ -2046,3 +2046,42 @@ pub struct WebhookTestResult {
     pub latency_ms: i64,
     pub error_message: String,
 }
+
+// ========== 丢失文件清理 ==========
+
+/// 请求丢失文件清理候选预览（Dart → Rust）。
+/// `request_id` 由 Dart 生成并回显于响应，配对请求-响应——超时重试后
+/// 到达的过期响应被 Dart 端丢弃，不会被新一轮订阅误消费（同
+/// `WebhookTestResult.request_id` 先例）。
+#[derive(Deserialize, DartSignal)]
+pub struct GetMissingCleanupCandidates {
+    pub request_id: String,
+}
+
+/// 执行丢失文件清理（Dart → Rust）。
+/// `task_ids` 为确认删除的任务 ID 列表（来自预览弹窗）；`request_id`
+/// 用途同上。
+#[derive(Deserialize, DartSignal)]
+pub struct ExecuteMissingCleanup {
+    pub request_id: String,
+    pub task_ids: Vec<String>,
+}
+
+/// 丢失文件清理候选预览结果（Rust → Dart）。
+/// 返回当前所有「已完成且文件确证丢失且曾确证存在」的任务列表，
+/// 供 Dart 端展示确认弹窗。
+#[derive(Serialize, RustSignal)]
+pub struct MissingCleanupCandidatesResult {
+    pub request_id: String,
+    pub candidates: Vec<TaskInfo>,
+}
+
+/// 丢失文件清理执行结果（Rust → Dart）。
+/// `deleted` 实际删除数，`healed` TOCTOU 自愈数（文件找回，未删除，
+/// 仅回收 file_missing 标记）——两者语义不同，Dart 端必须分别展示。
+#[derive(Serialize, RustSignal)]
+pub struct MissingCleanupExecuted {
+    pub request_id: String,
+    pub deleted: i32,
+    pub healed: i32,
+}

--- a/native/server/src/actor.rs
+++ b/native/server/src/actor.rs
@@ -250,10 +250,16 @@ pub enum ActorCmd {
         endpoint_json: String,
         ack: oneshot::Sender<Box<fluxdown_engine::webhook::WebhookDelivery>>,
     },
+    /// 扫描完成后触发丢失文件自动清理（若设置开启）。由 spawned 任务驱动，
+    /// 无回执：fire-and-forget，失败仅记日志不影响主循环。
+    AutoCleanupMissingFiles,
 }
 
 /// actor 主循环。持有 `Engine` 直至进程退出。
+/// `cmd_tx` 仅供 spawned 任务转发 `AutoCleanupMissingFiles` 等内部命令回
+/// actor 串行上下文，actor 自身不直接使用。
 pub async fn run_actor(
+    cmd_tx: mpsc::Sender<ActorCmd>,
     mut engine: Engine,
     mut cmd_rx: mpsc::Receiver<ActorCmd>,
     mut done_rx: mpsc::Receiver<TaskDone>,
@@ -271,6 +277,24 @@ pub async fn run_actor(
     // 积压 tick 造成扫描风暴。
     let mut rescan_timer = tokio::time::interval(Duration::from_secs(300));
     rescan_timer.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+    // 扫描完成 → 触发丢失文件自动清理（若设置开启）。
+    // 与 hub 同款模式：独立 spawned 任务监听 scan_done_notify，
+    // 通过 cmd_tx 转发为 ActorCmd 进入串行 actor 上下文。
+    let cleanup_scan_done = engine.manager.scan_done_notify();
+    let cleanup_cmd_tx = cmd_tx.clone();
+    tokio::spawn(async move {
+        loop {
+            cleanup_scan_done.notified().await;
+            if cleanup_cmd_tx
+                .send(ActorCmd::AutoCleanupMissingFiles)
+                .await
+                .is_err()
+            {
+                break; // actor 已退出
+            }
+        }
+    });
     rescan_timer.tick().await;
 
     // 队列定时调度 tick：引擎侧做边沿检测（每边沿每天至多一次 + 当日补
@@ -711,6 +735,35 @@ async fn handle_cmd(cmd: ActorCmd, engine: &mut Engine) {
                     serde_json::from_str(&endpoint_json).unwrap_or_default();
                 let _ = ack.send(Box::new(dispatcher.test_endpoint(spec).await));
             });
+        }
+        ActorCmd::AutoCleanupMissingFiles => {
+            // panic 不扩散：自动清理是后台路径，失败仅记日志。
+            let outcome = match futures_util::FutureExt::catch_unwind(std::panic::AssertUnwindSafe(
+                engine.manager.auto_cleanup_missing_files(),
+            ))
+            .await
+            {
+                Ok(o) => o,
+                Err(e) => {
+                    let msg = if let Some(s) = e.downcast_ref::<String>() {
+                        s.clone()
+                    } else if let Some(s) = e.downcast_ref::<&str>() {
+                        (*s).to_string()
+                    } else {
+                        "unknown panic".to_string()
+                    };
+                    log_info!("[server-actor] auto-cleanup panicked: {}", msg);
+                    Default::default()
+                }
+            };
+            if outcome.had_effect() {
+                log_info!(
+                    "[server-actor] auto-cleanup: deleted {}, healed {}",
+                    outcome.deleted,
+                    outcome.healed
+                );
+                engine.manager.load_and_send_all_tasks().await;
+            }
         }
     }
 }

--- a/native/server/src/main.rs
+++ b/native/server/src/main.rs
@@ -218,6 +218,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // actor 独占 engine；HTTP 层经 cmd_tx 写入。
     let (cmd_tx, cmd_rx) = mpsc::channel::<ActorCmd>(64);
     tokio::spawn(run_actor(
+        cmd_tx.clone(),
         engine,
         cmd_rx,
         done_rx,

--- a/test/sync_catalog_test.dart
+++ b/test/sync_catalog_test.dart
@@ -130,10 +130,10 @@ void main() {
       settings.dispose();
     });
 
-    test('has exactly the 51 keys listed in the sync contract v1', () {
-      // 5 appearance + 6 general + 8 ui + 15 download + 12 bt（5 + 7 做种） + 5 ed2k.
+    test('has exactly the 52 keys listed in the sync contract v1', () {
+      // 5 appearance + 6 general + 8 ui + 16 download + 12 bt（5 + 7 做种） + 5 ed2k.
       // 做种 7 项：ratio/post_ratio/time/inactive_time/operator/then_action/max_active.
-      expect(catalog.length, 51);
+      expect(catalog.length, 52);
     });
 
     test('every key matches the contract key pattern and length limit', () {


### PR DESCRIPTION
## 一句话

设置页新增「清理丢失文件」按钮 + 自动清理开关。点一下，把文件已被手动删掉的下载记录批量清掉。

Closes #230, Closes #153

## 改了哪里

**手动清理**（#230 要的一键按钮）：设置 → 下载 → 点「清理丢失文件的任务」→ 弹窗显示 N 条候选（≤5 条直接列出文件名）→ 确认删除。

**自动清理**（#153 要的开关）：开开关后，每次文件扫描结束自动跑一轮清理，不再弹窗。默认关闭。

## 具体行为

两种路径执行同一套引擎逻辑：

1. 查 DB 找出同时满足以下条件的任务：completed（status=3）、文件已缺失且曾经存在过（`downloaded_bytes > 0` 或完成时文件在场）、未在做种
2. 对 BT 任务，额外检查 staging 目录有无残留数据，有则跳过（用户可能还会续种）
3. 执行前对每个候选做 TOCTOU 复核：实时 stat 一次，文件找回则不删并自愈 `file_missing` 标记（计入 `healed` 单独展示）
4. 逐条删除 DB 记录（含关联 segments / torrent_files / artifacts / group）

**不会删的**：活跃任务（下载中/排队/准备）、做种中的 BT 任务、staging 有数据的 BT 任务、文件实际仍在磁盘上的任务、0 字节且从未确证落盘的任务（「从未落盘」不等于「被删」）。

## 变更文件

13 files, +1336/-40

| 层 | 文件 | 做了什么 |
|---|---|---|
| 引擎 | `db.rs` | 新增 `file_present_at` 列、`MISSING_CLEANUP_WHERE` 谓词（批量候选与单任务复核共用）、索引 `idx_tasks_missing_cleanup`、配置播种 |
| 引擎 | `download_manager.rs` | 候选扫描（Semaphore 限流 + 30s 总包 + BT staging 守卫）、TOCTOU 执行（1s stat + 5s staging 超时）、自动清理入口（热读开关） |
| Hub | `signals/mod.rs` | 4 个新信号，带 `request_id` 配对（同 `WebhookTestResult` 先例） |
| Hub | `download_actor.rs` | CleanupSignal 子枚举经 `AuxSignal` 合并泵入主 `select!`（不新增顶层分支）；三路 catch_unwind |
| Server | `actor.rs`, `main.rs` | `scan_done_notify` 监听 → `ActorCmd::AutoCleanupMissingFiles` |
| Dart | `settings_page.dart` | 开关卡片 + 清理按钮 + 确认弹窗（防重入 + 35s/120s 超时 + requestId 配对） |
| Dart | `settings_provider.dart` | 配置字段 + getter/setter |
| Dart | `translations.dart`, `en.json`, `zh.json` | 中英双语 i18n（12 键，含独立 healed 文案） |
| Dart | `sync_catalog.dart`, `sync_catalog_test.dart` | 云同步契约扩键（51→52） |

## 安全边界

- 活跃任务（status 0/1/5）永不进入候选集，只处理 completed
- 做种中/排队做种的 BT 任务被谓词排除（`seeding_status NOT IN (1, 8)`）
- BT staging 有残留数据时跳过；staging 检查包 5s 超时，死挂载按「有数据」fail-safe
- 执行前 TOCTOU 实时 stat（1s 超时）；超时或 stat 错误一律保守跳过
- 执行前资格复核与候选查询共用同一 SQL 谓词，语义零漂移
- 候选/执行信号带 `request_id` 配对，超时重试后到达的过期响应被 Dart 丢弃
- DB 删除用三路 match 确认（`Ok(None)` 才计数），不靠 `rows_affected`
- 自动清理默认关闭，需用户主动开启；开关实时读库热生效

## 测试

11 个新增引擎测试，全部通过：

`cargo test -p fluxdown_engine --lib -- missing_cleanup file_present_at auto_cleanup toctou`
→ **11 passed, 0 failed**

- `db.rs`（5）：谓词矩阵、`file_present_at` 盖章生命周期（单次/批量）、配置默认关闭、做种字面量对齐
- `download_manager.rs`（6）：BT staging 守卫（执行/候选编排）、TOCTOU 自愈、存在证据纵深防御、候选查询 DB 错误降级、自动清理开关契约

另：`flutter test` 490/490（含云同步契约扩键登记）；`cargo test -p fluxdown_server` 89/89。

## 已知局限

- 仅在 `file_missing` 标记更新后（文件扫描完成后）生效。刚删文件但未触发扫描时，候选列表可能为空
- BT 做种状态依赖 `seeding_status` 的准确性，引擎崩溃后重启可能存在短暂不一致
- headless server 暂无手动清理 REST / Web UI（只有自动路径），后续单独补
- 不支持「归档」，只有硬删除 DB 记录。#153 下 @doraemonkeys 提过的归档方向值得单独开 issue

---

重写完了。从 base 重置后重做的，5 个新提交 force-push 了。

评审的问题：

TOCTOU 那条——现在 `execute_missing_cleanup` 删之前会对每个候选 `try_exists` 一次，1 秒超时。文件还在就不删，把 `file_missing` 改 false，算进 `healed`。超时或者 stat 报错都跳过，宁可漏删也不错删。

format churn——重写只动了功能行，`translations.dart` 和 `settings_page.dart` 没混进换行调整。

测试数写 11 其实不到——现在确实是 11 个了（db.rs 下 5，download_manager.rs 下 6），PR 描述同步了。

自己复查又修了几个：

[必须修复] staging 检查 `spawn_blocking` 裸 await。死挂载上 JoinHandle 不回来，actor 直接卡死。加了 5 秒超时，超时就当有数据跳过。

[建议修改] 预览臂缺 `catch_unwind`，panic 能直接干死 actor。现在三路都兜了，server 侧也补了。

[建议修改] Dart 候选超时只有 5 秒，引擎那边最坏 30 秒，NAS 上点按钮必超时。而且上一轮的旧响应回来会被新订阅吃掉，展示的是过期数据。提到 35 秒了，信号加了 `request_id` 配对。

[建议修改] healed 之前复用「已移除」文案，等于告诉用户删了多少条实际上没删的记录。单独加了 i18n 键。

[建议修改] `final result;` 没类型，dynamic 会把 bincode 漂移从编译错误变成 120 秒假超时 toast。现在都是 `RustSignalPack<T>`。

验证：cargo check / clippy（-D warnings）/ fmt 三个 crate 干净。引擎 822 过（cdn probe 那个 WSL 上跑不过，base 也一样）。server 89/89，flutter test 490/490，flutter analyze 0 新增，i18n 对齐。

