### PR TITLE
fix(engine): SOCKS5 手动代理改用 socks5h 让 DNS 走代理侧解析

### DIFF
--- a/native/engine/src/proxy_config.rs
+++ b/native/engine/src/proxy_config.rs
@@ -89,7 +89,10 @@ impl ProxyType {
         match s {
             "https" => Self::Https,
             "socks4" => Self::Socks4,
-            "socks5" => Self::Socks5,
+            // `socks5h` (remote-DNS SOCKS5, see `Self::scheme`) accepted as an
+            // alias so a user manually typing it into a custom proxy URL field
+            // isn't silently downgraded to `Http`.
+            "socks5" | "socks5h" => Self::Socks5,
             _ => Self::Http,
         }
     }
@@ -104,12 +107,23 @@ impl ProxyType {
     }
 
     /// URL scheme used by reqwest's `Proxy::all(url)`.
+    ///
+    /// SOCKS5 uses `socks5h` (not `socks5`) so hostname resolution happens on
+    /// the proxy side rather than the client. reqwest's `socks5` scheme
+    /// resolves DNS *locally* before tunneling the connection through the
+    /// proxy by IP — for hosts under DNS-level blocking (e.g. Google/YouTube
+    /// domains behind the GFW), local resolution fails or returns a poisoned
+    /// address even though the proxy itself can reach the real host, making
+    /// the proxy silently useless for exactly the traffic it exists to route
+    /// (issue #251). SOCKS4 keeps `socks4` — remote resolution needs the
+    /// SOCKS4a extension, unverified against this reqwest version, and no
+    /// report covers it.
     pub fn scheme(&self) -> &'static str {
         match self {
             Self::Http => "http",
             Self::Https => "https",
             Self::Socks4 => "socks4",
-            Self::Socks5 => "socks5",
+            Self::Socks5 => "socks5h",
         }
     }
 
@@ -194,7 +208,7 @@ impl ProxyConfig {
         self.proxy_type.is_socks()
     }
 
-    /// Build the full proxy URL string, e.g. `socks5://user:pass@host:port`.
+    /// Build the full proxy URL string, e.g. `socks5h://user:pass@host:port`.
     ///
     /// Used by reqwest's `Proxy::all(url)` and for display purposes.
     /// Returns `None` if mode is `None` or host is empty.
@@ -1276,6 +1290,7 @@ mod tests {
         assert_eq!(ProxyType::parse_str("https"), ProxyType::Https);
         assert_eq!(ProxyType::parse_str("socks4"), ProxyType::Socks4);
         assert_eq!(ProxyType::parse_str("socks5"), ProxyType::Socks5);
+        assert_eq!(ProxyType::parse_str("socks5h"), ProxyType::Socks5);
         assert_eq!(ProxyType::parse_str("unknown"), ProxyType::Http);
         assert_eq!(ProxyType::parse_str(""), ProxyType::Http);
     }
@@ -1285,7 +1300,7 @@ mod tests {
         assert_eq!(ProxyType::Http.scheme(), "http");
         assert_eq!(ProxyType::Https.scheme(), "https");
         assert_eq!(ProxyType::Socks4.scheme(), "socks4");
-        assert_eq!(ProxyType::Socks5.scheme(), "socks5");
+        assert_eq!(ProxyType::Socks5.scheme(), "socks5h");
     }
 
     #[test]
@@ -1385,7 +1400,7 @@ mod tests {
         };
         assert_eq!(
             config.to_proxy_url().as_deref(),
-            Some("socks5://admin:secret@socks.example.com:1080")
+            Some("socks5h://admin:secret@socks.example.com:1080")
         );
     }
 
@@ -1766,7 +1781,7 @@ mod tests {
         // '@' and ':' in credentials must be percent-encoded
         assert!(url.contains("user%40domain"));
         assert!(url.contains("p%40ss%3Aword"));
-        assert!(url.starts_with("socks5://"));
+        assert!(url.starts_with("socks5h://"));
         assert!(url.ends_with("@proxy.com:1080"));
     }
 


### PR DESCRIPTION
## Repro
设置 → 代理 → 手动 → SOCKS5（如 `127.0.0.1:3067`），新建下载 YouTube 视频的任务（经 `flux.ytdlp` 提取 DASH 直链 `googlevideo.com`），点击下载。报告人给出真实错误日志：`DASH segment 0 failed after 3 attempts: request failed: error sending request for url (https://rr1---sn-oguelney.googlevideo.com/videoplayback...)`；关闭应用内代理、改用系统 TUN 模式代理可正常下载；下载 B站视频（DNS 未被污染）不受影响。

## Cause
`ProxyType::scheme()`（`native/engine/src/proxy_config.rs`）对 `ProxyType::Socks5` 一直返回 `"socks5"`，`ProxyConfig::to_proxy_url()` 据此拼出 `socks5://host:port` 交给 `reqwest::Proxy::all()`。reqwest 对 `socks5` scheme 的语义是**客户端本地解析目标 hostname**，只把解析出的 IP 经代理隧道连接；只有 `socks5h` scheme 才会让 DNS 解析发生在代理侧。这个 URL 被四处复用：`downloader::build_client_inner`（下载 client）、`DownloadManager::task_http_context`（任务级代理选择）、`plugin::bridge::EngineBridge::new`（插件网络出口）、`proxy_config::test_proxy_connection`（设置页“测试”按钮）。

对 DNS 层面被封锁/污染的域名（`googlevideo.com`/`youtube.com`），本地解析要么失败要么拿到污染后的错误地址——即便代理本身能连通真实主机也无济于事，因为请求在发出前目标就已经错了。这精确对应报告：SOCKS5 代理“测试”通过（探测目标域名未被污染，走的是同一个 socks5 scheme，只是没暴露问题）；B站不受影响；YouTube 的 DASH 分段下载在建连阶段失败，与是否手动给 yt-dlp 传 `--proxy` 无关（yt-dlp 只负责提取直链，实际分段下载是引擎自己的 reqwest client 做的）。

## Fix
- `ProxyType::scheme()`：`Socks5` 分支从 `"socks5"` 改为 `"socks5h"`，让四处共用的代理 client 构建统一改为代理侧 DNS 解析。SOCKS4 未改动（remote-DNS 需要 SOCKS4a 扩展，reqwest 是否支持未经验证，本次报告也不涉及 SOCKS4）。
- `ProxyType::parse_str()`：新增 `"socks5h"` 作为 `Socks5` 的别名，避免用户在自定义代理 URL 字段手打 `socks5h://...` 时被静默误判为 `Http`（该字段占位符是 `socks5://127.0.0.1:1080`，允许用户覆写 scheme）。
- 更新受影响单测的期望输出（`proxy_type_scheme`、`proxy_config_to_proxy_url_manual_with_auth`、`to_proxy_url_encodes_special_chars_in_credentials`），新增 `parse_str("socks5h")` 断言。

## Verification
未在机器人环境中构建或测试——运行环境无法承载本项目的 Rust 工具链（容器仅 2 核 1.8GB，见 `.agent/AGENTS.md` 运行限制）。本改动经静态审查：

- 通读了 `to_proxy_url()`/`scheme()`/`parse_str()` 的全部调用方（`grep` 确认 `.scheme()` 在整个 crate 内只有 `to_proxy_url()` 这一处调用点），确认改动不影响任何持久化的设置值（`as_str()`/DB 里的 `proxy_type` 列/Dart 侧 `sp.proxyType` 均使用未改动的 `as_str()`/`parse_str` 通配分支，与 `scheme()` 是两条独立路径）。
- 确认 Dart 侧 `manualProxyUrlFromSettings`（`lib/src/services/system_proxy_status.dart`）直接用 `sp.proxyType`（wire 字符串）拼 URL，不经过 Rust `to_proxy_url()`，不受本次改动影响，也不会把 `socks5h` 结果回传给 Rust 二次解析——排除了往返解析被 `parse_str` 曾经的通配 `_ => Http` 吞掉的风险（顺手加了 `socks5h` 别名兜底）。
- 比对了同文件 `to_proxy_url()`/`from_proxy_url()` 的既有测试写法，按同样风格更新/新增了断言。
- FTP 的 `socks5_connect_sync`（同文件）是独立的手写 SOCKS5 握手，直接传 `target_host: &str` 给代理端解析，本就不经过 `scheme()`，未受影响，未改动。

请维护者执行验证：
- `cargo check -p fluxdown_engine --lib`
- `cargo clippy -p fluxdown_engine -- -D warnings`
- `cargo nextest run -p fluxdown_engine proxy_config::`

已知未覆盖：无法在容器内实测真实 SOCKS5 代理连通性差异（依赖真实网络环境/GFW DNS 污染），修复的正确性完全基于对 reqwest `socks5` vs `socks5h` scheme 语义的静态判断，建议维护者用真实 SOCKS5 代理对 YouTube 下载做一次实测确认。

Fixes #251