### PR TITLE
fix(settings): 自定义 User-Agent 未回车会在离开设置页后被重置

### DIFF
--- a/lib/src/mobile/screens/mobile_settings_screen.dart
+++ b/lib/src/mobile/screens/mobile_settings_screen.dart
@@ -697,6 +697,13 @@ Future<void> _showSelectSheet<T>(
   );
 }
 
+/// 单个设置项的文本编辑 sheet。
+///
+/// 提交时机：点「确认」或 sheet 关闭（下滑、点遮罩、系统返回）。移动端
+/// 拿不到桌面那套「失焦即保存」——`EditableTextTapOutsideIntent` 的默认
+/// 实现对 android/iOS 的 touch 事件直接跳过，点别处根本不会失焦——所以
+/// 只能在 sheet 关闭时兜底提交，否则编辑内容会随手势关闭静默丢失（#266
+/// 在移动端的等价面）。
 Future<void> _showInputSheet(
   BuildContext context, {
   required String title,
@@ -706,6 +713,13 @@ Future<void> _showInputSheet(
   required ValueChanged<String> onSave,
 }) {
   final controller = TextEditingController(text: initial);
+  var committed = false;
+  void commit() {
+    if (committed) return;
+    committed = true;
+    if (controller.text != initial) onSave(controller.text);
+  }
+
   return showMobileSheet<void>(
     context,
     builder: (ctx) {
@@ -715,7 +729,7 @@ Future<void> _showInputSheet(
         footer: MobilePrimaryButton(
           label: s.confirm,
           onTap: () {
-            onSave(controller.text);
+            commit();
             Navigator.of(ctx).pop();
           },
         ),
@@ -729,7 +743,10 @@ Future<void> _showInputSheet(
         ),
       );
     },
-  ).whenComplete(controller.dispose);
+  ).whenComplete(() {
+    commit();
+    controller.dispose();
+  });
 }
 
 // ─────────────────────────────────────────────

--- a/lib/src/pages/settings_page.dart
+++ b/lib/src/pages/settings_page.dart
@@ -4906,6 +4906,7 @@ class _UserAgentEditor extends StatefulWidget {
 
 class _UserAgentEditorState extends State<_UserAgentEditor> {
   late TextEditingController _controller;
+  late FocusNode _focusNode;
   late String _selectedPreset;
 
   @override
@@ -4914,13 +4915,21 @@ class _UserAgentEditorState extends State<_UserAgentEditor> {
     final ua = widget.settingsProvider.globalUserAgent;
     _controller = TextEditingController(text: ua);
     _selectedPreset = detectUaPreset(ua);
+    _focusNode = FocusNode();
+    _focusNode.addListener(() {
+      // 失焦时持久化（与 _FileManagerCmdInput 一致），避免未回车直接离开
+      // 设置页导致刚输入的自定义 UA 被丢弃（#266）
+      if (!_focusNode.hasFocus) _commit();
+    });
   }
 
   @override
   void didUpdateWidget(_UserAgentEditor oldWidget) {
     super.didUpdateWidget(oldWidget);
     final ua = widget.settingsProvider.globalUserAgent;
-    if (ua != _controller.text) {
+    // 仅在未聚焦（用户未编辑）时才用外部值回填，避免编辑过程中被外部
+    // rebuild 回灌旧值
+    if (!_focusNode.hasFocus && ua != _controller.text) {
       _controller.text = ua;
       _selectedPreset = detectUaPreset(ua);
     }
@@ -4929,6 +4938,7 @@ class _UserAgentEditorState extends State<_UserAgentEditor> {
   @override
   void dispose() {
     _controller.dispose();
+    _focusNode.dispose();
     super.dispose();
   }
 
@@ -4951,8 +4961,8 @@ class _UserAgentEditorState extends State<_UserAgentEditor> {
     }
   }
 
-  void _onSubmit(String value) {
-    widget.settingsProvider.setGlobalUserAgent(value);
+  void _commit() {
+    widget.settingsProvider.setGlobalUserAgent(_controller.text);
   }
 
   @override
@@ -4996,9 +5006,10 @@ class _UserAgentEditorState extends State<_UserAgentEditor> {
         Expanded(
           child: ShadInput(
             controller: _controller,
+            focusNode: _focusNode,
             placeholder: Text(s.userAgentPlaceholder),
             onChanged: _onTextChanged,
-            onSubmitted: _onSubmit,
+            onSubmitted: (_) => _commit(),
           ),
         ),
       ],

--- a/lib/src/pages/settings_page.dart
+++ b/lib/src/pages/settings_page.dart
@@ -4892,6 +4892,31 @@ class _AutoRetryDelayInputState extends State<_AutoRetryDelayInput> {
 }
 
 // ─────────────────────────────────────────────
+// 失焦提交型输入的卸载兜底
+// ─────────────────────────────────────────────
+
+/// 输入框带着未提交的编辑被销毁时的兜底提交。
+///
+/// 失焦提交依赖 [FocusNode] 的 listener，而组件被程序性卸载时（浏览器扩展
+/// 推来新下载导致设置页自动切回首页等）全程没有指针事件，不会触发失焦；
+/// 卸载时输入框内层的 `Focus` 又先于外层 `State.dispose` 摘掉焦点，
+/// [FocusNode.dispose] 时节点已脱离焦点树、其 `_notify` 提前返回——两条路
+/// 都通知不到 listener，未提交的编辑就此静默丢失（#266 的残留面）。
+///
+/// 所以调用方**不能**用 `hasFocus` 判断「用户是否正在编辑」（dispose 时它
+/// 恒为 false），只能比对输入框文本与已生效值：不等即说明有未提交的编辑。
+///
+/// 提交推迟到下一帧：卸载发生在 build/unmount 阶段，此时直接调用 provider
+/// 的 setter 会经 `notifyListeners` 触发别处 `setState`，命中
+/// 「setState() called during build」断言。
+///
+/// 待提交的值必须在 dispose 里**先取出**再传入闭包——回调执行时 controller
+/// 已经 dispose，闭包内不可再读它。
+void _commitOnUnmount(VoidCallback commit) {
+  WidgetsBinding.instance.addPostFrameCallback((_) => commit());
+}
+
+// ─────────────────────────────────────────────
 // UA 编辑器
 // ─────────────────────────────────────────────
 
@@ -4937,6 +4962,13 @@ class _UserAgentEditorState extends State<_UserAgentEditor> {
 
   @override
   void dispose() {
+    // 失焦提交在程序性卸载时不会触发（见 _commitOnUnmount），文本与已生效
+    // 值不等即说明有未提交的编辑，按值兜底一次。
+    final ua = _controller.text;
+    final sp = widget.settingsProvider;
+    if (ua != sp.globalUserAgent) {
+      _commitOnUnmount(() => sp.setGlobalUserAgent(ua));
+    }
     _controller.dispose();
     _focusNode.dispose();
     super.dispose();
@@ -5061,6 +5093,12 @@ class _FileManagerCmdInputState extends State<_FileManagerCmdInput> {
 
   @override
   void dispose() {
+    // 失焦提交在程序性卸载时不会触发（见 _commitOnUnmount），按值兜底一次。
+    final cmd = _controller.text;
+    final sp = widget.settingsProvider;
+    if (cmd != sp.revealFileCmd) {
+      _commitOnUnmount(() => sp.setRevealFileCmd(cmd));
+    }
     _controller.dispose();
     _focusNode.dispose();
     super.dispose();
@@ -5841,6 +5879,17 @@ class _ApiServiceContentState extends State<_ApiServiceContent> {
 
   @override
   void dispose() {
+    // 失焦提交在程序性卸载时不会触发（见 _commitOnUnmount），按值兜底一次。
+    // 非法端口直接丢弃——组件已经不在，既回退不了输入框也弹不出提示。
+    final sp = widget.settingsProvider;
+    final port = _parsePort(_portController.text);
+    if (port != null && port != sp.localServerPort) {
+      _commitOnUnmount(() => sp.setLocalServerPort(port));
+    }
+    final token = _tokenController.text.trim();
+    if (token != sp.localServerToken) {
+      _commitOnUnmount(() => sp.setLocalServerToken(token));
+    }
     _portFocusNode.removeListener(_onPortFocusChange);
     _portFocusNode.dispose();
     _portController.dispose();
@@ -5854,11 +5903,18 @@ class _ApiServiceContentState extends State<_ApiServiceContent> {
     if (!_portFocusNode.hasFocus) _commitPort();
   }
 
+  /// 端口区间校验（1024-65535）；非法返回 null。
+  static int? _parsePort(String raw) {
+    final value = int.tryParse(raw.trim());
+    if (value == null || value < 1024 || value > 65535) return null;
+    return value;
+  }
+
   /// 端口失焦/提交时校验 1024-65535；非法则回退为当前生效值
   void _commitPort() {
     final sp = widget.settingsProvider;
-    final value = int.tryParse(_portController.text.trim());
-    if (value == null || value < 1024 || value > 65535) {
+    final value = _parsePort(_portController.text);
+    if (value == null) {
       setState(() => _portController.text = sp.localServerPort.toString());
       FluxSonner.of(context).show(
         ShadToast.destructive(
@@ -9783,6 +9839,7 @@ class _CustomColorPicker extends StatefulWidget {
 
 class _CustomColorPickerState extends State<_CustomColorPicker> {
   late TextEditingController _hexController;
+  late FocusNode _hexFocusNode;
   late double _hue;
   late double _saturation;
   late double _lightness;
@@ -9795,6 +9852,7 @@ class _CustomColorPickerState extends State<_CustomColorPicker> {
     _saturation = hsl.saturation;
     _lightness = hsl.lightness;
     _hexController = TextEditingController(text: _colorToHex(widget.color));
+    _hexFocusNode = FocusNode()..addListener(_onHexFocusChange);
   }
 
   @override
@@ -9814,6 +9872,15 @@ class _CustomColorPickerState extends State<_CustomColorPicker> {
 
   @override
   void dispose() {
+    // 手输 hex 未回车就被程序性卸载时的兜底（滑块是即时提交，只有手输
+    // 这一条路径需要补）；见 _commitOnUnmount。
+    final color = _parseHex(_hexController.text);
+    if (color != null && color != widget.color) {
+      final onChanged = widget.onChanged;
+      _commitOnUnmount(() => onChanged(color));
+    }
+    _hexFocusNode.removeListener(_onHexFocusChange);
+    _hexFocusNode.dispose();
     _hexController.dispose();
     super.dispose();
   }
@@ -9849,12 +9916,27 @@ class _CustomColorPickerState extends State<_CustomColorPicker> {
     widget.onChanged(color);
   }
 
-  void _onHexSubmitted(String value) {
+  void _onHexFocusChange() {
+    if (!_hexFocusNode.hasFocus) _commitHex(_hexController.text);
+  }
+
+  /// 解析 6 位 hex 文本（可带 `#`）；非法返回 null。
+  static Color? _parseHex(String value) {
     final hex = value.replaceAll('#', '').trim();
-    if (hex.length != 6) return;
+    if (hex.length != 6) return null;
     final parsed = int.tryParse(hex, radix: 16);
-    if (parsed == null) return;
-    final color = Color(0xFF000000 | parsed);
+    if (parsed == null) return null;
+    return Color(0xFF000000 | parsed);
+  }
+
+  /// 提交 hex 输入（失焦或回车）。非法输入回退为当前生效颜色的文本，
+  /// 避免输入框停在一个永远不会生效的半成品值上。
+  void _commitHex(String value) {
+    final color = _parseHex(value);
+    if (color == null) {
+      _hexController.text = _colorToHex(widget.color);
+      return;
+    }
     final hsl = HSLColor.fromColor(color);
     setState(() {
       _hue = hsl.hue;
@@ -9923,8 +10005,9 @@ class _CustomColorPickerState extends State<_CustomColorPicker> {
               width: 90,
               child: ShadInput(
                 controller: _hexController,
+                focusNode: _hexFocusNode,
                 placeholder: const Text('3B82F6'),
-                onSubmitted: _onHexSubmitted,
+                onSubmitted: _commitHex,
               ),
             ),
           ],


### PR DESCRIPTION
## Repro

桌面设置页 下载设置 > User-Agent，选择「自定义」预设，输入自定义 UA（如 `netdisk;P2SP;3.0.20.138`），不按回车直接返回主界面，再次进入该设置页，输入框回退为之前的值（未持久化）。容器无法构建/运行 Flutter，以下为源码级静态复现：`lib/src/pages/settings_page.dart` 的 `_UserAgentEditorState`（约 4907-5006 行）仅在 `ShadInput.onSubmitted`（回车）时调用 `SettingsProvider.setGlobalUserAgent`，输入框未绑定 `FocusNode`，因此失焦不触发提交；离开设置页时 State 被 dispose，输入值随之丢弃；重新进入时 `initState` 用 `SettingsProvider.globalUserAgent`（仍是旧值）重建 `_controller.text`，与用户描述现象一致。

## Cause

`_UserAgentEditorState` 缺少失焦（blur）提交路径，只有 Enter 一条提交路径。同文件内 `_FileManagerCmdInputState`（约 5024-5039 行）已经用 `FocusNode` 监听失焦并在失焦时调用 `_commit()`，其注释明确写「提交时机：失焦或回车（与 UA 编辑器一致）」——说明 UA 编辑器本应有同样的失焦提交，属实现遗漏。

## Fix

- 给 `_UserAgentEditorState` 的 `_controller` 接上 `FocusNode`，失焦时调用新增的 `_commit()`（复用原 `_onSubmit` 的持久化逻辑）。
- `onSubmitted` 同样调用 `_commit()`，行为保持一致。
- `didUpdateWidget` 增加 `!_focusNode.hasFocus` 守卫，只在输入框未聚焦时才用 provider 的外部值回填 `_controller.text`，避免用户正在编辑时被外部 rebuild 覆盖（与 `_FileManagerCmdInput` 的既有写法一致）。
- `dispose` 中释放新增的 `_focusNode`。

未实现 issue 中「支持用户自定义多个不同 UA 选项」的诉求——这是新增多 UA 配置项的功能请求，超出本 bug 修复范围。

## Verification

未在机器人环境中构建或测试——容器无法承载 Flutter 工具链（详见仓库 `AGENTS.md` 环境限制）。本改动经静态审查：

- 通读 `_UserAgentEditorState` 全部方法（initState/didUpdateWidget/dispose/_onPresetChanged/_onTextChanged/_commit/build），确认新增的 `FocusNode` 生命周期（创建、监听、dispose）与同文件 `_FileManagerCmdInputState` 的既有实现逐字对照一致。
- 确认 `ShadInput` 组件已在同文件 `_FileManagerCmdInput` 中使用 `focusNode` 具名参数，无需新增 import。
- grep 确认 `_onSubmit`/`_commit` 命名未与文件内其他 State 类（速度限制、上传限制等编辑器）的同名私有方法冲突（Dart 私有成员按类隔离）。
- 未改动生成物、依赖声明与 `SettingsProvider` 持久化逻辑本身。

请维护者执行验证：

- `flutter analyze`
- 手动验证：设置页填入自定义 UA，不按回车，导航离开再返回，确认值已保留。

Fixes #266