### PR TITLE
fix(mobile): stop truncating error message on task detail page

### DIFF
--- a/lib/src/mobile/pages/mobile_task_detail_page.dart
+++ b/lib/src/mobile/pages/mobile_task_detail_page.dart
@@ -421,21 +421,15 @@ class _ProgressCard extends StatelessWidget {
                   style: TextStyle(fontSize: 12, color: c.textSecondary),
                 ),
               ],
-              if (task.status == TaskStatus.error) ...[
-                Expanded(
-                  child: Text(
-                    task.errorMessage.isEmpty
-                        ? s.subtitleError
-                        : task.errorMessage,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    textAlign: TextAlign.end,
-                    style: TextStyle(fontSize: 12, color: c.statusError),
-                  ),
-                ),
-              ],
             ],
           ),
+          if (task.status == TaskStatus.error) ...[
+            const SizedBox(height: 6),
+            Text(
+              task.errorMessage.isEmpty ? s.subtitleError : task.errorMessage,
+              style: TextStyle(fontSize: 12, color: c.statusError),
+            ),
+          ],
           const SizedBox(height: 12),
           MobileProgressBar(
             progress: task.isIndeterminate ? 1.0 : task.progress,


### PR DESCRIPTION
## Repro
下载失败后打开移动端「任务详情」页，进度卡片顶部与 34sp 百分比数字同一行右对齐显示的错误信息被截断为一行加 `...`（截图见 #265：`probes failed: HEAD=400, ranged GET=...`），用户无法看到完整失败原因。静态复现：走读 `lib/src/mobile/pages/mobile_task_detail_page.dart` 的 `_ProgressCard.build()` 渲染逻辑，对照失败任务的 `errorMessage` 字段。

## Cause
`_ProgressCard`（`lib/src/mobile/pages/mobile_task_detail_page.dart:424-436`，修复前）在 `task.status == TaskStatus.error` 时，把 `task.errorMessage` 塞进与百分比大字号文本同一个 `Row` 的 `Expanded(Text(..., maxLines: 1, overflow: TextOverflow.ellipsis, textAlign: TextAlign.end))` 里。该 Row 的可用宽度已被 34sp 百分比文本占用，稍长的错误串必然被裁剪。对比同一页面下方的 `_InfoCard.row()`（716-758 行）和桌面端 `lib/src/widgets/detail_panel.dart` 的 `_buildErrorRow`（1472-1504 行），两处都是独立整行展示、无 maxLines/overflow 限制，可以完整换行——说明进度卡片头部这处单行截断是局部实现疏漏，并非刻意设计。

## Fix
- 把错误文本从与百分比数字共享的 `Row` 中移出，改为该 Row 下方独立的全宽 `Text`，不设 `maxLines`/`overflow`，与页面内 `_InfoCard` 及桌面端 `_buildErrorRow` 的展示方式保持一致。
- 百分比/速度/剩余时间那一行不再承载错误文案，恢复其原本的简洁布局。

## Verification
未在机器人环境中构建或测试——运行环境无法承载本项目的 Flutter 工具链（无 `flutter analyze`/`flutter run` 能力）。本改动经静态审查：

- 完整读过 `lib/src/mobile/pages/mobile_task_detail_page.dart:368-448` 的 `_ProgressCard` 类改动前后逻辑，`s`/`c`/`active`/`barColor` 等局部变量作用域未变，Column/Row 的花括号与 children 列表保持平衡。
- 对照同文件 `_InfoCard.row()`（716-758 行）与桌面端 `detail_panel.dart` 的 `_buildErrorRow`（1472-1504 行）的既有写法，未引入新的截断/溢出处理风格。
- 未改动 `DownloadTask.errorMessage` 字段定义、生成物或依赖声明。

请维护者执行验证：

- `flutter analyze`
- 移动端手测：制造一个 HTTP 探测失败任务（错误串足够长），打开任务详情页确认进度卡片头部的错误文案完整换行显示，不再截断。

已知未覆盖：`lib/src/mobile/screens/mobile_tasks_screen.dart` 的任务列表行（`_MetaLine`）与 `lib/src/widgets/task_group_card.dart` 的分组卡片成员行仍对状态文案做单行省略截断，这是列表/卡片视图的空间约束（与桌面端分组卡片一致的既有约定），本次未改动；如需在列表视图也展示完整错误信息，建议另开 issue 讨论。

Fixes #265