### PR TITLE
fix(extension): route task panel through remoteMode, not NMH-only

### DIFF
--- a/fluxDown/entrypoints/background.ts
+++ b/fluxDown/entrypoints/background.ts
@@ -36,10 +36,10 @@ import {
   checkFluxDownAvailable,
   checkFluxDownAvailableWithRetry,
   warmupNativeHost,
+  listTasks,
+  taskOp,
 } from "@/utils/download-dispatch";
 import {
-  nmhListTasks,
-  nmhTaskOp,
   nmhOpenFile,
   nmhRevealFile,
   nmhWarmupNativeHost,
@@ -2131,12 +2131,13 @@ export default defineBackground(() => {
   // 仅当"已知存在活跃任务"（pending/downloading/preparing）时才创建低频
   // periodic alarm 轮询任务列表；无活跃任务时清除 alarm，避免长期空转。
   // 活跃感知来源：
-  //   a) 本地下载请求发送成功后（sendToFluxDown / batchDownload），乐观地
+  //   a) 下载请求发送成功后（sendToFluxDown / batchDownload），乐观地
   //      认为"可能有活跃任务"，启动 alarm；
   //   b) 每次拿到任务列表（无论来自 alarm 轮询还是 popup 的 nmh-tasks 消息）
   //      时按其中是否存在活跃状态任务续期或停止。
-  // 远程模式下投递到远程服务器的任务不经过本地 NMH，nmhListTasks 天然拿不
-  // 到它们，故本轮询自动不参与远程任务的完成通知。
+  // 轮询经 download-dispatch 的 listTasks() 按 remoteMode 路由（off 走 NMH、
+  // always 走远程管理 API、fallback 优先 NMH 不可达时改投远程），与下载投递
+  // 路由完全一致——远程任务同样参与完成通知（按 notifyRemoteTask 开关）。
 
   const TASK_POLL_ALARM_NAME = "fluxdown-task-poll";
   // Chrome 对 periodInMinutes < 0.5 不予兑现（会被夹到 30s 一次；未打包的
@@ -2167,9 +2168,12 @@ export default defineBackground(() => {
     }
   }
 
-  /** download/batchDownload 成功发送后调用：远程通道不参与本地完成通知。 */
-  function maybeArmTaskPollForChannel(channel?: "local" | "remote"): void {
-    if (channel === "remote") return;
+  /**
+   * download/batchDownload 成功发送后调用：确保任务轮询 alarm 已启用。
+   * 通道无关——listTasks() 内部按 remoteMode 自动路由到正确来源，远程任务
+   * 同样需要这条 alarm 驱动完成通知（见上方大注释）。
+   */
+  function maybeArmTaskPollForChannel(_channel?: "local" | "remote"): void {
     ensureTaskPollAlarm().catch(() => {});
   }
 
@@ -2236,7 +2240,10 @@ export default defineBackground(() => {
    * Firefox（MV2 不支持 buttons）：降级为点击通知主体 = 打开文件夹
    * （onClicked 处理，见下方监听器）。
    */
-  function notifyTaskCompleted(task: TaskBrief): void {
+  function notifyTaskCompleted(
+    task: TaskBrief,
+    channel: "local" | "remote",
+  ): void {
     if (!browser.notifications?.create) return;
     const notificationId = `${TASK_NOTIFICATION_PREFIX}${task.taskId}`;
     const opts: Record<string, any> = {
@@ -2247,7 +2254,9 @@ export default defineBackground(() => {
         name: task.fileName || task.taskId,
       }),
     };
-    if (!import.meta.env.FIREFOX) {
+    // 打开文件/文件夹按钮走 NMH open_file/reveal_file，只对本地任务有意义——
+    // 远程任务的文件在 fluxdown_server 主机上，本机没有对应路径可打开。
+    if (!import.meta.env.FIREFOX && channel === "local") {
       opts.buttons = [
         { title: t("notify.openFile") },
         { title: t("notify.openFolder") },
@@ -2297,6 +2306,7 @@ export default defineBackground(() => {
 
   async function processTasksPollResultInner(
     tasks: TaskBrief[],
+    channel: "local" | "remote",
   ): Promise<void> {
     const prevSnapshot = await loadTaskSnapshot();
     const nextSnapshot: Record<string, number> = {};
@@ -2315,12 +2325,9 @@ export default defineBackground(() => {
     }
     persistTaskSnapshot(nextSnapshot);
 
-    if (newlyCompleted.length > 0) {
-      const settings = await loadSettings();
-      if (settings.notifyLocalTask === true) {
-        for (const task of newlyCompleted) {
-          notifyTaskCompleted(task);
-        }
+    if (newlyCompleted.length > 0 && (await shouldNotifyChannel(channel))) {
+      for (const task of newlyCompleted) {
+        notifyTaskCompleted(task, channel);
       }
     }
 
@@ -2339,19 +2346,22 @@ export default defineBackground(() => {
    * 活跃任务决定续期还是清除轮询 alarm。alarm 触发与 popup 的 nmh-tasks
    * 轮询共用此函数，保证两条路径下的通知/alarm 状态完全一致。
    */
-  function processTasksPollResult(tasks: TaskBrief[]): Promise<void> {
+  function processTasksPollResult(
+    tasks: TaskBrief[],
+    channel: "local" | "remote",
+  ): Promise<void> {
     _taskSnapshotChain = _taskSnapshotChain.then(() =>
-      processTasksPollResultInner(tasks),
+      processTasksPollResultInner(tasks, channel),
     );
     return _taskSnapshotChain;
   }
 
   browser.alarms.onAlarm.addListener((alarm) => {
     if (alarm.name !== TASK_POLL_ALARM_NAME) return;
-    nmhListTasks()
+    listTasks()
       .then((result) => {
-        if (!result.success) return; // App 暂不可达，等下一轮
-        return processTasksPollResult(result.tasks);
+        if (!result.success) return; // 当前通道暂不可达，等下一轮
+        return processTasksPollResult(result.tasks, result.channel);
       })
       .catch((e) => {
         console.warn("[FluxDown] task poll alarm handler failed:", e);
@@ -2726,16 +2736,28 @@ export default defineBackground(() => {
     //     历史消息的 `action` 字段并存，互不冲突。---
     switch (message.type) {
       case "nmh-tasks": {
-        const result = await nmhListTasks();
+        const result = await listTasks();
         if (!result.success) {
-          return { ok: false, connected: false, tasks: [] };
+          return {
+            ok: false,
+            connected: false,
+            tasks: [],
+            channel: result.channel,
+          };
         }
-        await processTasksPollResult(result.tasks);
-        return { ok: true, connected: true, tasks: result.tasks };
+        await processTasksPollResult(result.tasks, result.channel);
+        return {
+          ok: true,
+          connected: true,
+          tasks: result.tasks,
+          channel: result.channel,
+        };
       }
       case "nmh-task-op": {
         const op = message.op;
         const taskId = message.taskId;
+        const channel: "local" | "remote" =
+          message.channel === "remote" ? "remote" : "local";
         if (
           typeof taskId !== "string" ||
           !taskId ||
@@ -2743,7 +2765,7 @@ export default defineBackground(() => {
         ) {
           return { ok: false, message: "invalid_request" };
         }
-        const result = await nmhTaskOp(op, taskId);
+        const result = await taskOp(op, taskId, channel);
         return { ok: result.success, message: result.message };
       }
       case "nmh-open-file": {

--- a/fluxDown/entrypoints/popup/main.ts
+++ b/fluxDown/entrypoints/popup/main.ts
@@ -69,6 +69,7 @@ const statFailed = $('#statFailed')!;
 
 // 任务面板
 const taskDisconnectedEl = $('#taskDisconnected')!;
+const taskDisconnectedTitleEl = taskDisconnectedEl.querySelector('.task-state-title')!;
 const taskEmptyEl = $('#taskEmpty')!;
 const taskGroupsEl = $('#taskGroups')!;
 const downloadingGroupEl = $('#downloadingGroup')!;
@@ -217,6 +218,8 @@ interface NmhTasksResponse {
   ok: boolean;
   connected: boolean;
   tasks: TaskBrief[];
+  /** 本次数据来源通道；任务操作（暂停/继续/删除）需要回传同一通道。 */
+  channel?: 'local' | 'remote';
 }
 
 interface NmhOpResponse {
@@ -232,6 +235,9 @@ const TASK_STATUS = {
   ERROR: 4,
   PREPARING: 5,
 } as const;
+
+/** 最近一次成功轮询的数据来源通道，任务操作按此路由（见 download-dispatch.ts taskOp 文档）。 */
+let _lastChannel: 'local' | 'remote' = 'local';
 
 async function nmhTasks(): Promise<NmhTasksResponse> {
   try {
@@ -253,6 +259,7 @@ async function nmhTaskOp(
       type: 'nmh-task-op',
       op,
       taskId,
+      channel: _lastChannel,
     })) as NmhOpResponse | undefined;
     return res ?? { ok: false };
   } catch (e) {
@@ -572,6 +579,11 @@ function resetStartAppState(): void {
 }
 
 startAppBtn.addEventListener('click', () => {
+  if (remoteModeSelect.value === 'always') {
+    // 远程模式没有本地应用可"启动"——点击视为手动重试一次连接探测。
+    void pollTasksOnce();
+    return;
+  }
   if (appStarting) return;
   appStarting = true;
   setStartAppLoading(true);
@@ -583,9 +595,27 @@ startAppBtn.addEventListener('click', () => {
   }, 8000);
 });
 
+/**
+ * 断线态文案随远程模式切换：「仅远程」模式没有本地 App 可言，误导性的
+ * "启动 FluxDown" 按钮换成「重试」；跳过 appStarting 期间的覆写，避免
+ * 每秒轮询把"启动中…"文案打回原样。
+ */
+function syncDisconnectedUi(): void {
+  const isRemoteOnly = remoteModeSelect.value === 'always';
+  taskDisconnectedTitleEl.textContent = t(
+    isRemoteOnly ? 'popup.tasks.remoteUnreachable' : 'popup.tasks.appNotRunning',
+  );
+  if (!appStarting) {
+    startAppBtn.querySelector('.btn-label')!.textContent = t(
+      isRemoteOnly ? 'popup.tasks.retry' : 'popup.tasks.startApp',
+    );
+  }
+}
+
 function renderTaskPanel(connected: boolean, tasks: TaskBrief[]): void {
   quickDownloadRow.classList.toggle('hidden', !connected);
   if (!connected) {
+    syncDisconnectedUi();
     taskDisconnectedEl.classList.remove('hidden');
     taskEmptyEl.classList.add('hidden');
     taskGroupsEl.classList.add('hidden');
@@ -622,6 +652,7 @@ async function pollTasksOnce(): Promise<void> {
   pollInFlight = true;
   try {
     const res = await nmhTasks();
+    if (res.channel) _lastChannel = res.channel;
     renderTaskPanel(res.connected, res.tasks);
   } finally {
     pollInFlight = false;

--- a/fluxDown/utils/download-dispatch.ts
+++ b/fluxDown/utils/download-dispatch.ts
@@ -3,7 +3,7 @@
  *
  * 职责：根据用户设置的 remoteMode，在 NMH（桌面 App，Native Messaging）与
  * 远程 HTTP 下载源（fluxdown_server）之间路由下载请求 / 可用性探测，对上层
- * （background.ts、popup）暴露与 native-messaging.ts 完全同名同签名的 5 个
+ * （background.ts、popup）暴露与 native-messaging.ts 完全同名同签名的
  * 导出函数——调用方只需换 import 源，函数名、参数、返回值形状不变。
  *
  * === 路由策略（FluxDownSettings.remoteMode） ===
@@ -41,11 +41,14 @@ import type {
   ApiResponse,
   DownloadRequest,
   BatchDownloadItem,
+  TaskBrief,
 } from "./native-messaging";
 import {
   remoteSendDownloadRequest,
   remoteSendBatchDownloadRequest,
   remotePing,
+  remoteListTasks,
+  remoteTaskOp,
 } from "./remote-server";
 import type { RemoteServerConfig } from "./remote-server";
 import { loadSettings } from "./settings";
@@ -237,4 +240,54 @@ export async function checkFluxDownAvailableWithRetry(): Promise<boolean> {
       .catch(() => false),
   ]);
   return nmhUp || remoteUp;
+}
+
+export interface ListTasksResult {
+  success: boolean;
+  tasks: TaskBrief[];
+  message?: string;
+  /** 实际取数的通道；popup 展示 + taskOp 路由都复用该字段。 */
+  channel: "local" | "remote";
+}
+
+/**
+ * 拉取任务面板列表，按 remoteMode 路由数据来源：
+ *   - "off"：NMH。
+ *   - "always"：远程管理 API（GET /api/v1/tasks）。
+ *   - "fallback"：优先 NMH；本轮 NMH 拉取失败（nmhListTasks 不区分具体
+ *     原因，单次失败即视为"未连接"，见该函数文档）时改用远程列表——与
+ *     sendDownloadRequest 的路由哲学一致：单次只反映一个真实来源，不合并
+ *     两侧列表（taskId 命名空间不共享，合并没有意义）。
+ */
+export async function listTasks(): Promise<ListTasksResult> {
+  const cfg = toRoutingConfig(await getRoutingSettings());
+  const mode = effectiveMode(cfg);
+
+  if (mode === "off") {
+    return { ...(await nmh.nmhListTasks()), channel: "local" };
+  }
+  if (mode === "always") {
+    return { ...(await remoteListTasks(cfg.remote)), channel: "remote" };
+  }
+
+  const local = await nmh.nmhListTasks();
+  if (local.success) return { ...local, channel: "local" };
+  return { ...(await remoteListTasks(cfg.remote)), channel: "remote" };
+}
+
+/**
+ * 任务操作（暂停/继续/删除）：channel 由调用方回填 listTasks() 返回的通道
+ * ——同一时刻任务面板只展示一个来源，操作必须投给同一后端，不能按
+ * remoteMode 重新判定（fallback 模式下两次轮询间通道可能已切换）。
+ */
+export async function taskOp(
+  op: "pause" | "resume" | "remove",
+  taskId: string,
+  channel: "local" | "remote",
+): Promise<ApiResponse> {
+  if (channel === "remote") {
+    const cfg = toRoutingConfig(await getRoutingSettings());
+    return remoteTaskOp(op, taskId, cfg.remote);
+  }
+  return nmh.nmhTaskOp(op, taskId);
 }

--- a/fluxDown/utils/locales/en.ts
+++ b/fluxDown/utils/locales/en.ts
@@ -229,6 +229,8 @@ const en: Record<MessageKey, string> = {
   "popup.tasks.appNotRunning": "FluxDown is not running",
   "popup.tasks.startApp": "Start FluxDown",
   "popup.tasks.starting": "Starting…",
+  "popup.tasks.remoteUnreachable": "Cannot connect to the remote server",
+  "popup.tasks.retry": "Retry",
   "popup.tasks.statsToday": "Today:",
   "popup.tasks.statsLineTitle": "Open settings for details",
   "popup.task.pause": "Pause",

--- a/fluxDown/utils/locales/zh-CN.ts
+++ b/fluxDown/utils/locales/zh-CN.ts
@@ -215,6 +215,8 @@ const zhCN = {
   "popup.tasks.appNotRunning": "FluxDown 未运行",
   "popup.tasks.startApp": "启动 FluxDown",
   "popup.tasks.starting": "启动中…",
+  "popup.tasks.remoteUnreachable": "无法连接到远程服务器",
+  "popup.tasks.retry": "重试",
   "popup.tasks.statsToday": "今日：",
   "popup.tasks.statsLineTitle": "打开设置查看更多",
   "popup.task.pause": "暂停",

--- a/fluxDown/utils/remote-server.ts
+++ b/fluxDown/utils/remote-server.ts
@@ -20,6 +20,7 @@ import type {
   ApiResponse,
   DownloadRequest,
   BatchDownloadItem,
+  TaskBrief,
 } from "./native-messaging";
 
 /** remote-server 所需的最小配置（对应 FluxDownSettings 的 remoteUrl/remoteToken 子集） */
@@ -34,6 +35,11 @@ export interface RemoteServerConfig {
 const DOWNLOAD_TIMEOUT_MS = 15000;
 // ping 探活超时：短超时，用于快速判定远程是否在线（fallback 路由决策 / popup 测试连接）。
 const PING_TIMEOUT_MS = 4000;
+// 任务面板轮询超时：与 native-messaging.ts 的 TASKS_POLL_TIMEOUT_MS 同一语义——
+// 低频轮询，失败直接视为"未连接"，不重试，等下一轮自然恢复。
+const TASKS_POLL_TIMEOUT_MS = 3000;
+// 任务操作（暂停/继续/删除）超时：与 DOWNLOAD_TIMEOUT_MS 同量级，预留网络抖动余量。
+const TASK_OP_TIMEOUT_MS = 10000;
 
 /** ping 成功时的附加信息（服务端 /ping 返回 {app, version, message: "pong"}） */
 export interface RemotePingResult extends ApiResponse {
@@ -50,7 +56,10 @@ function buildHeaders(cfg: RemoteServerConfig): HeadersInit {
 }
 
 /**
- * 统一 POST JSON 请求，把 fetch 异常/HTTP 状态码整形为 ApiResponse。
+ * 通用 JSON 请求：把 fetch 异常/HTTP 状态码整形为 ApiResponse。
+ * remoteSendDownloadRequest/remoteSendBatchDownloadRequest（POST）与
+ * remoteTaskOp（PUT/DELETE）共用这条路径；remoteListTasks 的响应体是裸
+ * 数组、不套 ApiResponse 契约，未走这里，单独实现解析。
  *
  * message 前缀约定（供上层字符串匹配，不做本地化——本地化由 popup/dispatch 按
  * 前缀映射到 i18n key）：
@@ -59,9 +68,10 @@ function buildHeaders(cfg: RemoteServerConfig): HeadersInit {
  *   - "remote_unreachable"：fetch 抛异常（网络错误/超时/DNS 失败等）
  *   - 其余：服务端业务返回的失败信息（HTTP 状态非 2xx 或 body.success=false）
  */
-async function postJson(
+async function requestJson(
   url: string,
   cfg: RemoteServerConfig,
+  method: string,
   body: unknown,
   timeoutMs: number,
 ): Promise<ApiResponse> {
@@ -72,9 +82,9 @@ async function postJson(
   let resp: Response;
   try {
     resp = await fetch(url, {
-      method: "POST",
+      method,
       headers: buildHeaders(cfg),
-      body: JSON.stringify(body),
+      body: body !== undefined ? JSON.stringify(body) : undefined,
       signal: AbortSignal.timeout(timeoutMs),
     });
   } catch (err) {
@@ -108,7 +118,13 @@ export async function remoteSendDownloadRequest(
   req: DownloadRequest,
   cfg: RemoteServerConfig,
 ): Promise<ApiResponse> {
-  return postJson(`${cfg.remoteUrl}/download`, cfg, req, DOWNLOAD_TIMEOUT_MS);
+  return requestJson(
+    `${cfg.remoteUrl}/download`,
+    cfg,
+    "POST",
+    req,
+    DOWNLOAD_TIMEOUT_MS,
+  );
 }
 
 /** 批量投递下载请求：POST {remoteUrl}/download/batch，body 为 {items:[...]} */
@@ -116,9 +132,10 @@ export async function remoteSendBatchDownloadRequest(
   items: BatchDownloadItem[],
   cfg: RemoteServerConfig,
 ): Promise<ApiResponse> {
-  return postJson(
+  return requestJson(
     `${cfg.remoteUrl}/download/batch`,
     cfg,
+    "POST",
     { items },
     DOWNLOAD_TIMEOUT_MS,
   );
@@ -192,4 +209,89 @@ export async function remoteVerify(
     return { success: false, message: "remote_auth_failed" };
   }
   return ping;
+}
+
+/**
+ * 拉取远程任务列表：GET {remoteUrl}/api/v1/tasks（管理 API，裸数组响应，
+ * 与 postJson/requestJson 的 ApiResponse 包裹契约不同，单独实现解析）。
+ *
+ * TaskDto 与 TaskBrief 字段一一对应（camelCase 契约一致），唯一缺口是
+ * speed——管理 API 是纯轮询接口，不含引擎的实时限速数字（只经 WebSocket
+ * 推送），远程任务列表的 speed 恒为 0。
+ */
+export async function remoteListTasks(
+  cfg: RemoteServerConfig,
+): Promise<{ success: boolean; tasks: TaskBrief[]; message?: string }> {
+  if (!cfg.remoteUrl) {
+    return { success: false, tasks: [], message: "remote_not_configured" };
+  }
+
+  let resp: Response;
+  try {
+    resp = await fetch(`${cfg.remoteUrl}/api/v1/tasks`, {
+      method: "GET",
+      headers: buildHeaders(cfg),
+      signal: AbortSignal.timeout(TASKS_POLL_TIMEOUT_MS),
+    });
+  } catch (err) {
+    return {
+      success: false,
+      tasks: [],
+      message: `remote_unreachable: ${String(err)}`,
+    };
+  }
+
+  if (resp.status === 401 || resp.status === 403) {
+    return { success: false, tasks: [], message: "remote_auth_failed" };
+  }
+  if (!resp.ok) {
+    return { success: false, tasks: [], message: `HTTP ${resp.status}` };
+  }
+
+  const data = await resp.json().catch(() => null);
+  if (!Array.isArray(data)) {
+    return { success: false, tasks: [], message: "remote_bad_response" };
+  }
+
+  return {
+    success: true,
+    tasks: data.map((task: Record<string, unknown>) => ({
+      taskId: String(task.taskId ?? ""),
+      fileName: String(task.fileName ?? ""),
+      status: Number(task.status ?? 0),
+      downloadedBytes: Number(task.downloadedBytes ?? 0),
+      totalBytes: Number(task.totalBytes ?? 0),
+      speed: 0,
+      errorMessage:
+        typeof task.errorMessage === "string" && task.errorMessage
+          ? task.errorMessage
+          : undefined,
+      createdAt: String(task.createdAt ?? ""),
+    })),
+  };
+}
+
+/**
+ * 远程任务操作：暂停 / 继续 / 删除。语义同 nmhTaskOp——remove 对已删除任务
+ * 重发幂等，pause/resume 重发到达同一目标状态同样无害。
+ */
+export async function remoteTaskOp(
+  op: "pause" | "resume" | "remove",
+  taskId: string,
+  cfg: RemoteServerConfig,
+): Promise<ApiResponse> {
+  const path =
+    op === "pause"
+      ? `/api/v1/tasks/${taskId}/pause`
+      : op === "resume"
+        ? `/api/v1/tasks/${taskId}/continue`
+        : `/api/v1/tasks/${taskId}`;
+  const method = op === "remove" ? "DELETE" : "PUT";
+  return requestJson(
+    `${cfg.remoteUrl}${path}`,
+    cfg,
+    method,
+    undefined,
+    TASK_OP_TIMEOUT_MS,
+  );
 }


### PR DESCRIPTION
## Repro

静态代码追踪（机器人环境无法起浏览器+headless server 联调）：`fluxDown/entrypoints/popup/main.ts` 的 `pollTasksOnce()` → `nmhTasks()` → `chrome.runtime.sendMessage({type:'nmh-tasks'})` → `background.ts` 的 `nmh-tasks` 处理器 → 修复前直接调用 `native-messaging.ts` 的 `nmhListTasks()`（只经 `connectNative('com.fluxdown.nmh')` 跟桌面 App 通信）。当用户只跑 headless `fluxdown_server`（Web 版），没有桌面 App/NMH 进程时，哪怕在 Options 页配置好远程服务器地址+令牌、点「测试连接」通过、把「投递模式」切到「仅远程」，任务面板仍然只会显示「FluxDown 未运行」+ 空列表——即使下载已经在正常投递到远程服务器（对应 issue #271 的现象）。`background.ts` 里此前留有一段注释直接承认了这个缺口："远程模式下投递到远程服务器的任务不经过本地 NMH，nmhListTasks 天然拿不到它们"。

## Cause

扩展的「远程下载源」功能只把 `sendDownloadRequest`/`sendBatchDownloadRequest`/`checkFluxDownAvailable*`（`download-dispatch.ts`）按 `remoteMode`（off/fallback/always）路由到 NMH 或远程管理 API，但任务列表/任务操作/完成通知从未接入这条路由层：`background.ts` 的 `nmh-tasks`/`nmh-task-op` 消息处理器与任务完成通知的 `chrome.alarms` 轮询都直接调用 NMH-only 的 `nmhListTasks`/`nmhTaskOp`，导致 popup 头部徽标（走 `checkFluxDownAvailable`，是 remoteMode-aware 的）与任务面板（写死 NMH）这两个连接信号互相矛盾。

## Fix

- `remote-server.ts`：新增 `remoteListTasks()`（`GET /api/v1/tasks`，管理 API）与 `remoteTaskOp()`（`PUT .../pause`、`PUT .../continue`、`DELETE`）；把原来 POST-only 的 `postJson` 提炼成通用的 `requestJson`，GET/PUT/POST/DELETE 共用同一套 fetch 异常/HTTP 状态整形逻辑。
- `download-dispatch.ts`：新增 `listTasks()`/`taskOp()`，复用既有的 off/always/fallback 路由哲学——`fallback` 优先 NMH，仅当本轮 NMH 拉取失败时才整批改用远程列表（不合并两侧列表，taskId 命名空间不共享）。
- `background.ts`：`nmh-tasks`/`nmh-task-op` 消息处理器与任务完成通知的 alarm 轮询改为调用 `listTasks()`/`taskOp()`；`processTasksPollResult`/`notifyTaskCompleted` 携带实际数据来源通道，完成通知的「打开文件」「打开文件夹」按钮只在本地通道下出现（远程任务的文件在服务器主机上，本机没有对应路径可打开）；`maybeArmTaskPollForChannel` 不再对远程通道跳过——远程任务同样需要 alarm 驱动完成通知。
- `popup/main.ts`：任务操作回传上一次轮询的实际通道供 `nmh-task-op` 使用；「仅远程」模式下的断线态把「启动 FluxDown」（NMH 预热，无意义）换成「重试」+「无法连接到远程服务器」文案（本地没有可启动的东西）。
- `en.ts`/`zh-CN.ts`：新增 `popup.tasks.remoteUnreachable`/`popup.tasks.retry` 文案对。

## Verification

未在机器人环境中跑浏览器/headless server 集成测试（无 GUI/NMH 环境）。已做的验证：

- `cd fluxDown && bunx tsc --noEmit -p .`：改动前后错误行数均为 53 行且**逐字完全相同**（仅因新增代码上移导致行号平移，用 `git stash`/`git stash pop` 对比确认），确认这些错误全部是 `chrome` 全局类型、WXT 宏（`injectScript`/`createShadowRootUi`）、`bun:test` 类型声明缺失等与本次改动无关的既有基线噪音（裸 `tsc` 脱离 WXT 实际构建管线的已知副作用），本次改动**零新增类型错误**。
- 通读了 `native-messaging.ts`/`remote-server.ts`/`download-dispatch.ts`/`background.ts`/`popup/main.ts` 的完整任务面板调用链，确认新路由函数的入参/返回值形状与既有 `nmhListTasks`/`nmhTaskOp`/`ApiResponse` 契约逐字段对齐（管理 API `TaskDto` 与 `TaskBrief` 除 `speed` 外 camelCase 字段一一对应；`speed` 恒为 0，因管理 API 是纯轮询接口、不含引擎的实时限速数字）。
- `gh_push_branch`/`gh_open_pr` 的 `bun run fix` + `bun check` 门禁均已通过。

Fixes #271