### PR TITLE
fix(extension): hide stale video float button on scroll

### DIFF
--- a/fluxDown/entrypoints/resource-ui.content/index.ts
+++ b/fluxDown/entrypoints/resource-ui.content/index.ts
@@ -239,6 +239,16 @@ export default defineContentScript({
       floatTimer = setTimeout(hideFloat, 400);
     }, true);
 
+    // 浮标定位在 mouseover 时按 video.getBoundingClientRect() 计算一次并写死为
+    // position:fixed 的视口坐标，此后不会随滚动重算；页面滚动时 video 已经移开，
+    // 浮标却仍钉在原视口位置，遮挡滚动后出现的其他内容（#275）。滚动即隐藏，
+    // 下次 hover 到视频时 showFloat() 会重新按当前坐标显示。
+    document.addEventListener('scroll', () => {
+      if (!floatBtnEl?.classList.contains('visible')) return;
+      if (floatTimer) { clearTimeout(floatTimer); floatTimer = null; }
+      hideFloat();
+    }, { capture: true, passive: true });
+
     /* ================================================================
      *  构建 DOM
      * ================================================================ */


### PR DESCRIPTION
## Repro
在带 `<video>` 元素的页面上，鼠标悬停视频触发浮动下载按钮显示后，滚动页面而不再次悬停视频，按钮会停在原视口坐标不动，随内容滚动脱节并以最高层级悬浮遮挡新出现的内容。命令：无法在机器人容器中构建/运行扩展，通过静态代码审查复现（见下方 Cause）。

## Cause
`showFloat()`（`fluxDown/entrypoints/resource-ui.content/index.ts:837-856`）在 `mouseover` 命中 `<video>` 时用 `getBoundingClientRect()` 只计算一次坐标，写死为 `.fluxdown-float-btn` 的 `position: fixed` 视口像素（`z-index: 2147483647`，`fluxDown/entrypoints/resource-ui.content/style.css:721-723`）。全文件没有 scroll/resize 监听器会重算或隐藏它——唯一的隐藏路径是 `mouseout` 命中视频区域（`index.ts:237-240`），滚动本身不保证触发该事件。

## Fix
- 在 `mouseover`/`mouseout` 监听器之后新增一个 capture 阶段的 `scroll` 监听器（`index.ts:246-250`）：页面滚动时若浮标当前可见，立即清掉待触发的隐藏计时器并调用 `hideFloat()`。
- 复用既有的 hover-to-show / leave-to-hide 交互模型（与 `mouseout` 的 400ms 延迟隐藏、`previewModalEl?.classList` 的可选链写法保持一致），不引入新状态或新的视觉样式。
- 下次 hover 到视频时 `showFloat()` 会按当前坐标重新显示，行为不变。

## Verification
未在机器人环境中构建或测试——运行环境无法承载本项目的 npm/bun 工具链（详见仓库 AGENTS.md 对机器人容器的限制）。本改动经静态审查：

- 通读 `fluxDown/entrypoints/resource-ui.content/index.ts` 全文件，确认改动前后 `floatBtnEl`/`floatTimer`/`hoverVideo` 的类型与生命周期一致，未引入新的空引用路径（`floatBtnEl?.classList` 写法与同文件 210 行 `previewModalEl?.classList.contains('visible')` 的既有防御式写法完全一致）。
- 确认 `document.addEventListener('scroll', ..., { capture: true, passive: true })` 与同文件其余 capture 阶段监听器（`mouseover`/`mouseout`/`click`，`index.ts:229-240,618`）风格一致，`passive: true` 因回调不调用 `preventDefault()` 而安全。
- 未改动生成物、依赖声明或其他文件。
- 本仓库对该 UI content script 没有既有单测基础设施（`fluxDown/**/*.test.ts` 仅覆盖 `utils/` 下的纯函数，如 `resource-types.test.ts`），且该模块是重 DOM/异步初始化的 WXT content script，未搭建可运行的测试骨架，因此未新增自动化测试。

请维护者执行验证：

- `cd fluxDown && bun run build`（或 `bun run dev`）后加载未打包扩展，打开任意带视频的页面，悬停视频触发浮标显示，随后滚动页面，确认浮标立即消失、不再遮挡内容，再次悬停视频时浮标在正确位置重新出现。

已知未覆盖：报告中提出的「固定到角落」或「增加开关选项」两个替代方案未实现——`fluxDown/utils/settings.ts` 中已有 `showFloatingButton` 字段与 i18n 文案但从未接入 options 页面（属于独立的功能补全，非本次修复范围）。

Fixes #275