### PR TITLE
fix(scoop): restore github checkver object for fluxdown manifest

### DIFF
--- a/bucket/fluxdown.json
+++ b/bucket/fluxdown.json
@@ -28,7 +28,9 @@
     "persist": [
         "settings.json"
     ],
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/zerx-lab/FluxDown"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
## Repro
`scoop checkver fluxdown` (or `.\bin\checkver.ps1 fluxdown` in the bucket repo) fails with `ERROR fluxdown checkver expects the homepage to be a github repository`, then 404s trying to fetch `https://fluxdown.zerx.dev/releases/latest` — exactly as reported in #283.

## Cause
`bucket/fluxdown.json:31` used the Scoop `checkver` shorthand `"checkver": "github"`. Per Scoop's manifest docs (App-Manifest-Autoupdate wiki, "Special Cases"), this shorthand requires `homepage` itself to be the GitHub repository URL. This manifest's `homepage` is `https://fluxdown.zerx.dev` (the marketing site), not a GitHub URL, so checkver falls back to treating homepage as the repo and 404s on `/releases/latest`. Commit 32302c1 ("fix(scoop): align manifest with Extras conventions") introduced this regression by replacing the previously-correct object form with the shorthand.

## Fix
- Restore `"checkver": {"github": "https://github.com/zerx-lab/FluxDown"}` in `bucket/fluxdown.json`, keeping `homepage` pointed at the marketing site while telling checkver the actual repo to query for releases.

## Verification
- `python3 -c "import json; json.load(open('bucket/fluxdown.json'))"` — valid JSON.
- Confirmed the shorthand-vs-object semantics against Scoop's official wiki (`App-Manifest-Autoupdate#special-cases`): shorthand `checkver: "github"` requires `homepage` to be the GitHub repo; object form `checkver.github` decouples them, matching this manifest's real setup.
- Restored config is byte-identical to the pre-regression manifest from before commit 32302c1, and matches the reporter's expected fix in #283.
- Not run through `scoop install`/`checkver.ps1` (no Windows/Scoop environment available); the reporter's log plus the wiki contract are the evidence.

Fixes #283