### PR TITLE
临时解决via调用问题 不建议合并到main 单独建一个分支 创建测试版用于过度via更新即可 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,6 +1466,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.28",
  "rquickjs",
+ "rustls",
  "serde",
  "serde_json",
  "sha1 0.10.6",
@@ -3739,6 +3740,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
+ "webpki-roots",
  "web-sys",
 ]
 

--- a/android/app/src/main/kotlin/com/fluxdown/app/ExternalDownloadActivity.kt
+++ b/android/app/src/main/kotlin/com/fluxdown/app/ExternalDownloadActivity.kt
@@ -20,7 +20,8 @@ import org.json.JSONObject
  *
  * 与 [MainActivity] 共享同一个 FlutterEngine（见 [FluxdownEngine]）。share 与
  * storage channel 优先在 [configureFlutterEngine] 绑定，确保 Dart 冷启动拉取分享前
- * handler 已就绪；[onStart] 保留幂等兜底。
+ * handler 已就绪；[onStart] 保留幂等兜底。另作为 MainActivity 转发老调用方
+ * 下载请求的落点：把带下载参数的 intent 原样转到这里即可复用完整弹窗流程。
  */
 class ExternalDownloadActivity : FlutterActivity() {
     override fun getBackgroundMode(): BackgroundMode = BackgroundMode.transparent

--- a/android/app/src/main/kotlin/com/fluxdown/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/fluxdown/app/MainActivity.kt
@@ -13,6 +13,11 @@ import io.flutter.embedding.engine.FlutterEngine
  * 同一个 FlutterEngine（见 [FluxdownEngine]），保持单 Dart 会话、下载状态、
  * Rust 桥与前台服务不重复初始化。
  *
+ * 兼容老调用方：某些应用/浏览器用显式 intent 硬编码调起本入口并携带下载数据
+ * （ACTION_SEND / VIEW 的 http/https/magnet/ed2k/fluxdown 直链）。此时把原
+ * intent 原样转发给 [ExternalDownloadActivity]（透明弹新建下载框），结束自身，
+ * 让成熟的下载弹窗流程接管——老版本调用方无需改动即可走外部下载。
+ *
  * channel 优先在 [configureFlutterEngine] 中绑定，确保 Dart entrypoint 执行前即可响应；
  * [onStart] 对旧 embedding 或 cached engine 的差异提供幂等兜底。
  */
@@ -21,6 +26,9 @@ class MainActivity : FlutterActivity() {
         if (FluxdownEngine.cached != null) FluxdownEngine.ENGINE_ID else null
 
     override fun shouldDestroyEngineWithHost(): Boolean = false
+
+    /** 下载请求只转发一次（onCreate/onStart/onNewIntent 多处可触发，防重复弹窗）。 */
+    private var downloadForwarded = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         // 桌面图标再进：部分 ROM 会在已有任务上再叠一个 MAIN/LAUNCHER
@@ -33,6 +41,7 @@ class MainActivity : FlutterActivity() {
             return
         }
         super.onCreate(savedInstanceState)
+        forwardIfDownloadRequest(intent)
     }
 
     override fun detachFromFlutterEngine() {
@@ -52,6 +61,7 @@ class MainActivity : FlutterActivity() {
             FluxdownEngine.cacheIfAbsent(engine)
             AppStorage.bind(engine, this)
         }
+        forwardIfDownloadRequest(intent)
     }
 
     override fun onDestroy() {
@@ -64,5 +74,37 @@ class MainActivity : FlutterActivity() {
         if (!AppStorage.onActivityResult(this, requestCode, resultCode, data)) {
             super.onActivityResult(requestCode, resultCode, data)
         }
+    }
+
+    /** 热启动（singleTask）：应用已在任务栈中被前台化，新 intent 到达。 */
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        forwardIfDownloadRequest(intent)
+    }
+
+    /** 携带下载参数的外部调用（区别于纯 MAIN/LAUNCHER 桌面启动）→ 转发并结束自身。 */
+    private fun forwardIfDownloadRequest(intent: Intent) {
+        if (downloadForwarded || !isDownloadRequest(intent)) return
+        downloadForwarded = true
+        startActivity(
+            Intent(intent).apply {
+                setClass(this@MainActivity, ExternalDownloadActivity::class.java)
+            },
+        )
+        finish()
+    }
+
+    /** 是否带可下载载荷：SEND 有分享文本；VIEW 的 data scheme 属下载直链。 */
+    private fun isDownloadRequest(intent: Intent): Boolean = when (intent.action) {
+        Intent.ACTION_SEND, Intent.ACTION_SEND_MULTIPLE ->
+            !intent.getStringExtra(Intent.EXTRA_TEXT).isNullOrBlank()
+        Intent.ACTION_VIEW -> intent.data?.scheme?.lowercase() in DOWNLOAD_SCHEMES
+        else -> false
+    }
+
+    private companion object {
+        val DOWNLOAD_SCHEMES =
+            setOf("http", "https", "magnet", "ed2k", "fluxdown")
     }
 }

--- a/native/engine/Cargo.toml
+++ b/native/engine/Cargo.toml
@@ -74,7 +74,7 @@ libc = "0.2"
 librqbit = { version = "9", default-features = false, features = ["rust-tls"] }
 # default-features = false：去掉 default-tls（native-tls→openssl，Android 交叉编译无 openssl）；
 # 其余默认特性显式保留，Linux/macOS 行为不变
-reqwest = { version = "0.12", default-features = false, features = ["stream", "rustls-tls-native-roots", "cookies", "json", "socks", "charset", "http2", "system-proxy", "macos-system-configuration"] }
+reqwest = { version = "0.12", default-features = false, features = ["stream", "rustls-tls-native-roots", "rustls-tls-webpki-roots", "cookies", "json", "socks", "charset", "http2", "system-proxy", "macos-system-configuration"] }
 
 [dev-dependencies]
 http = "1.4.0"

--- a/native/engine/Cargo.toml
+++ b/native/engine/Cargo.toml
@@ -41,6 +41,9 @@ rand = "0.9"
 quick-xml = { version = "0.41", features = ["encoding"] }
 regex = "1"
 rquickjs = { version = "0.12.1", features = ["full-async", "parallel"], optional = true }
+# 显式锁定 rustls 的 ring provider。librqbit 9 fork 会启用 aws_lc_rs 特性，
+# 把全局默认 CryptoProvider 切成 aws-lc-rs，导致 Android/iOS 全 HTTPS 握手失败。
+rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1"
 sha1 = "0.10"

--- a/native/engine/src/lib.rs
+++ b/native/engine/src/lib.rs
@@ -223,6 +223,11 @@ impl Engine {
         sink: Arc<dyn EventSink>,
         selector: Arc<dyn HostSelection>,
     ) -> Result<Self, EngineError> {
+        // librqbit 9 fork 启用了 rustls 的 aws_lc_rs 特性，会把全局默认 TLS
+        // 供应商从 ring 静默切成 aws-lc-rs，导致 Android/iOS 上所有 HTTPS 握手
+        // 失败（纯 HTTP 不受影响）。此处强制锁回 ring；若已有 provider 被装则
+        // install_default 返回 Err，可安全忽略。
+        let _ = rustls::crypto::ring::default_provider().install_default();
         // 读回持久化的域名连接上限观察（过期/旧版本数据在加载时丢弃）。
         segment_coordinator::load_domain_conn_caps(&db).await;
         // 读回持久化的 CDN 节点健康度（多节点聚合的跨任务先验，同上范式）。


### PR DESCRIPTION
# 兼容老调用方：MainActivity 转发外部下载 intent 到 ExternalDownloadActivity

> 分支：`feat/mobile-legacy-main-activity-download` ｜ 提交：`96c85dd`
> 定位：**过渡性补丁**，仅用于兼容仍硬编码调用 `MainActivity` 的老版本调用方（如 via）。
> **不推荐在正式版长期使用**，等 via 修正调用类后应回退本改动。

---

## 一、背景与问题

FluxDown 的外部下载唤起走的是 `ExternalDownloadActivity`（透明窗口 + 独立任务栈，弹新建下载框，
关窗返回来源应用）。但部分老调用方（浏览器 / via 等）**用显式 intent 硬编码调起 `MainActivity`**，
而不是 `ExternalDownloadActivity`。

而 `MainActivity` 只是桌面 Launcher + 存储桥宿主，**没有注册任何分享/VIEW intent-filter，也不解析
intent 里的下载数据**。结果：

- 老调用方把带 URL 的 download/查看意图发到 `MainActivity`，FluxDown 只被当作"从桌面图标启动"，
  **下载意图被直接吞掉，用户点了没反应**。

## 二、本版方案（转发式）

在 `MainActivity` 里检测"携带下载参数的 intent"，命中后把 **原 intent 原样转发**给
`ExternalDownloadActivity` 并结束自身，让成熟的透明弹窗下载流程接管。老调用方无需任何改动。

判断条件（`isDownloadRequest`）：

| 动作 | 判定 |
| ---- | ---- |
| `ACTION_SEND` / `ACTION_SEND_MULTIPLE` | `EXTRA_TEXT` 分享文本非空 |
| `ACTION_VIEW` | `data` 的 scheme ∈ {`http`, `https`, `magnet`, `ed2k`, `fluxdown`} |

命中后执行 `startActivity(Intent(intent).setClass(MainActivity → ExternalDownloadActivity))` 再 `finish()`。

冷/热启动都覆盖：`onCreate`、`onStart`、`onNewIntent` 三处调用统一入口
`forwardIfDownloadRequest(intent)`，并用 `downloadForwarded` 保证只转发一次。

---

## 三、改动的文件 / 改动的地方 / 改动的作用

### 1. `android/app/src/main/kotlin/com/fluxdown/app/MainActivity.kt`（唯一功能性改动）

| 位置 | 改动 | 作用 |
| ---- | ---- | ---- |
| `forwardIfDownloadRequest(intent)`（新增私有方法） | 命中下载参数时转发到 `ExternalDownloadActivity` 并 `finish()` | 让老调用方发到 MainActivity 的下载意图改由下载弹窗流程处理 |
| `isDownloadRequest(intent)`（新增私有方法） | 判定 SEND 文本 / VIEW 下载 scheme | 区分"纯桌面启动"与"携带下载参数的调用" |
| 常量 `DOWNLOAD_SCHEMES` | `http/https/magnet/ed2k/fluxdown` | 下载直链 scheme 白名单 |
| 字段 `downloadForwarded` | 只转发一次的幂等守卫 | 防止 onCreate/onStart/onNewIntent 多处触发导致重复弹窗 |
| `onCreate` / `onStart` | 追加调用 `forwardIfDownloadRequest` | 覆盖冷启动路径 |
| `onNewIntent` | 追加调用 `forwardIfDownloadRequest` | 覆盖 singleTask 热启动（应用已在栈内被前台化）路径 |

### 2. `android/app/src/main/kotlin/com/fluxdown/app/ExternalDownloadActivity.kt`

仅追加两行 `KDoc` 注释（说明它兼作 MainActivity 的转发落点），**无任何行为变化**。

### 3. 未改动

- Dart 侧代码：无。
- `AndroidManifest.xml`：无（MainActivity 本就没有分享/VIEW filter；老调用方靠显式 intent 才能命中，属预期）。
- 其他 Kotlin 文件：均未改。

---

## 四、缺陷说明（重要）

**核心问题：会产生"两次跳转"，观感诡异。**

1. 老调用方 → `MainActivity` →（立刻）转发 → `ExternalDownloadActivity`。用户会短暂看到
   `MainActivity` 的界面（不透明 MainTheme splash / 主界面），随后再跳到透明 `ExternalDownloadActivity`
   弹窗。**画面先闪一下主界面，再闪成下载弹窗**，体验割裂、可能卡顿。
2. `MainActivity` 会初始化一次 Flutter 窗口/视图（虽然引擎是共享的，但仍会 attach 并渲染一帧），
   比"直接从浏览器点链接进 FluxDown"多了一次启动开销。
3. `finish()` 会**移除 MainActivity 所在的主界面任务**。若用户后台本来就留着 FluxDown 主界面，
   这次调用会把那个任务栈关掉，与"进入主界面"的直觉不符（本方案实际直奔下载弹窗而非主界面）。
4. 依赖 `ExternalDownloadActivity` 的 `singleInstance` + 独立任务栈，两个任务栈之间切换，
   返回/退出顺序在部分场景可能不顺滑。
5. 对 scheme 的判断是"白名单式"，只覆盖 5 种下载 scheme；其他协议（如自定义 `someapp://`）不会被转发。

**结论**：它能正确兼容"老调用方硬编码 `MainActivity`"这一现状，但代价是额外的中转跳转与观感劣化。
因此**仅适合作短期过渡**。

---

## 五、推荐定位与回退

- ✅ 仅用于**过渡期**：在 via 等老调用方尚未把调用类修正为 `ExternalDownloadActivity` 时，先上线兜底，
  让用户能正常下载。
- ⛔ **不推荐在正式版长期使用**：中转跳转的观感与任务栈行为会拖累体验。
- 🔧 **后续**：等 via 修正调用类后，**应回退本改动**（撤销 `MainActivity.kt` 的转发逻辑即可，
  恢复其纯 Launcher 职责）。回退非常干净，因为功能性改动全部收敛在单个文件。

---

## 六、验证

```bash
# 冷启动：先 force-stop，再带 URL 显式唤起 MainActivity
adb shell am force-stop com.fluxdown.app
adb shell am start -n com.fluxdown.app/.MainActivity -a android.intent.action.VIEW -d "https://example.com/a.bin"
# 预期：出现下载弹窗（URL 预填）

# 热启动：先打开主界面到后台，再执行上面的 VIEW 命令
# 预期：弹下载框

# 回归桌面启动：不带数据
adb shell am start -n com.fluxdown.app/.MainActivity
# 预期：只进主界面，不误弹下载框

# 回归原 ExternalDownloadActivity：magnet / fluxdown:// 仍照常
adb shell am start -a android.intent.action.VIEW -d "magnet:?xt=urn:btih:test"
```