### PR TITLE
fix(macos): disable Impeller to fix window hang on Intel iGPUs

### DIFF
--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -28,6 +28,8 @@
 	<string>FluxDown uses notifications to alert you when downloads complete.</string>
 	<key>CFBundleDisplayName</key>
 	<string>FluxDown</string>
+	<key>FLTEnableImpeller</key>
+	<false/>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
Fixes #549

## Problem
On Haswell-era Intel Macs (Intel Iris / Iris Pro, e.g. MacBookPro11,x), FluxDown launches but **never shows a window**: the process stays alive in the Dock, and the only way out is Force Quit.

Root cause: the **Impeller MetalSDF** backend deadlocks before the first frame on these GPUs. The main thread blocks inside Metal's legacy (`MetalOld`) shader/pipeline compilation which never returns:

```
Thread_main  main
  __psynch_cvwait
  XPCCompilerConnection::BuildRequest (MetalOld.dylib)
  -[_MTLDevice newRenderPipelineStateWithDescriptor:completionHandler:]
  semaphore_wait_trap   <- never returns
```

Reproduced on **macOS 14.8.9** and **native macOS 12.7.6** (this is not an OCLP / Legacy-Metal-patch artifact; the hardware simply predates the GPUs Impeller targets).

## Fix
Set `FLTEnableImpeller=false` in `macos/Runner/Info.plist`.

- The Flutter macOS embedder chooses the renderer **only** from this plist key at engine creation — there is no runtime, per-device switch (verified in `FlutterEngine.mm::runWithEntrypoint`; the `FLUTTER_ENGINE_SWITCHES="--no-impeller"` env workaround does not work on macOS).
- With Impeller off, the engine falls back to **Skia/Metal**, which renders correctly on these machines (log shows `Using the Skia rendering backend (Metal)` and the window appears normally).

## Trade-off
This forces Skia on all macOS build variants, including Apple Silicon, where Impeller gives better performance. Given the desktop client is already being migrated from Flutter to GPUI (roadmap #539), this is a cheap, temporary guarantee that the current Flutter macOS release actually *opens* on Intel machines. The long-term fix belongs in the Flutter engine itself.