### PR TITLE
fix(native): Windows 打开文件夹与定位文件改用标准 Shell API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2799,6 +2799,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "windows-sys 0.59.0",
  "winreg",
  "x25519-dalek",
 ]

--- a/lib/src/models/download_task.dart
+++ b/lib/src/models/download_task.dart
@@ -754,9 +754,11 @@ class DownloadTask {
 
   /// 「打开所在文件夹」应传给原生层的路径。
   ///
-  /// 已完成且文件存在时返回完整文件路径，便于文件管理器定位并选中文件；下载中、
-  /// 暂停、失败、排队、准备中、文件丢失等状态下最终文件可能尚未落盘，改为返回
-  /// 保存目录 [saveDir]，避免原生层将不存在的文件路径误判后打不开任何位置。
+  /// 已完成且文件存在时返回完整文件路径，文件管理器打开父目录时可据此选中
+  /// 文件（Windows 走 SHOpenFolderAndSelectItems，macOS open -R、Linux
+  /// D-Bus ShowItems 同样支持选中）；下载中、暂停、失败、排队、准备中、
+  /// 文件丢失等状态下最终文件可能尚未落盘，改为返回保存目录 [saveDir]，
+  /// 避免原生层将不存在的文件路径误判后打不开任何位置。
   /// [saveDir] 为空时退回文件路径。
   String get revealFolderPath {
     if (status == TaskStatus.completed && !fileMissing) return filePath;

--- a/lib/src/pages/settings_page.dart
+++ b/lib/src/pages/settings_page.dart
@@ -41,6 +41,7 @@ import '../services/link/local_pairing_service.dart';
 import '../services/local_interfaces.dart';
 import '../services/kv_store.dart';
 import '../services/log_service.dart';
+import '../services/open_folder.dart';
 import '../services/update_service.dart';
 import '../theme/app_colors.dart';
 import '../theme/app_metrics.dart';
@@ -11269,14 +11270,9 @@ class _LogExportCardState extends State<_LogExportCard> {
   }
 
   void _openLogDir() {
-    final path = LogService.instance.logDir.path;
-    if (Platform.isWindows) {
-      Process.run('explorer', [path]);
-    } else if (Platform.isMacOS) {
-      Process.run('open', [path]);
-    } else {
-      Process.run('xdg-open', [path]);
-    }
+    // 统一走 Rust open 动词链路（openFolder → reveal_file.rs），不再硬编码
+    // explorer，默认文件管理器（含第三方）由系统 open 关联解析。
+    openFolder(LogService.instance.logDir.path);
   }
 
   @override

--- a/lib/src/services/open_folder.dart
+++ b/lib/src/services/open_folder.dart
@@ -38,7 +38,11 @@ const _storageChannel = MethodChannel('com.fluxdown/storage');
 ///   1. 用户在设置中配置了自定义命令模板（reveal_file_cmd / open_dir_cmd）
 ///      → 走模板（cmd /c 或 sh -c），支持任意第三方文件管理器
 ///   2. 否则走平台默认：
-///      Windows: 文件→第三方默认 FM 打开父目录，否则 explorer /select；目录→cmd /c start
+///      Windows: 先探测「打开目录」默认处理程序是否为第三方文件管理器
+///      （只改 HKCR\Directory\shell\open\command 的 FM 拦截不到 Shell API），
+///      命中→ShellExecuteW("open") 仅打开父目录；否则 SHOpenFolderAndSelectItems
+///      （标准 Shell API）打开父目录并选中文件，失败回退 ShellExecuteW("open")；
+///      目录→ShellExecuteW("open")
 ///      macOS:   open -R 或 open
 ///      Linux:   D-Bus FileManager1.ShowItems 或 xdg-open
 ///

--- a/lib/src/widgets/doctor_report_view.dart
+++ b/lib/src/widgets/doctor_report_view.dart
@@ -9,7 +9,6 @@
 // 这里既不崩也不留白，UI 无需同步改动即可先把新结论展示出来。
 
 import 'dart:async';
-import 'dart:io' show Platform, Process;
 
 import 'package:flutter/services.dart' show Clipboard, ClipboardData;
 import 'package:flutter/widgets.dart';
@@ -20,6 +19,7 @@ import '../bindings/bindings.dart';
 import '../i18n/locale_provider.dart';
 import '../models/settings_provider.dart';
 import '../services/log_service.dart';
+import '../services/open_folder.dart';
 import '../theme/app_colors.dart';
 import '../theme/app_metrics.dart';
 import 'flux_sonner.dart';
@@ -223,14 +223,9 @@ class _DoctorReportViewState extends State<DoctorReportView> {
   }
 
   void _openLogDir() {
-    final path = LogService.instance.logDir.path;
-    if (Platform.isWindows) {
-      Process.run('explorer', [path]);
-    } else if (Platform.isMacOS) {
-      Process.run('open', [path]);
-    } else {
-      Process.run('xdg-open', [path]);
-    }
+    // 统一走 Rust open 动词链路（openFolder → reveal_file.rs），不再硬编码
+    // explorer，默认文件管理器（含第三方）由系统 open 关联解析。
+    openFolder(LogService.instance.logDir.path);
   }
 
   /// 这一条检查项能就地做什么。`null` = 没有可用动作（正常项 / 只能重装）。

--- a/native/agent/Cargo.toml
+++ b/native/agent/Cargo.toml
@@ -40,4 +40,8 @@ uuid = { version = "1.23.4", features = ["v4", "serde"] }
 x25519-dalek = { version = "3", features = ["static_secrets", "zeroize"] }
 
 [target.'cfg(windows)'.dependencies]
+# ShellExecuteW("open")：open/reveal 回退的标准「打开」调用（见 platform/mod.rs）
+# Win32_UI_Shell_Common：SHParseDisplayName / SHOpenFolderAndSelectItems（ITEMIDLIST 类型，见 platform/mod.rs）
+# 固定 0.59：0.61 引入 windows-link(raw-dylib)，与 cdylib 构建在 CI 上不兼容
 winreg = "0.55"
+windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_Com", "Win32_UI_Shell", "Win32_UI_Shell_Common", "Win32_UI_WindowsAndMessaging"] }

--- a/native/agent/src/platform/mod.rs
+++ b/native/agent/src/platform/mod.rs
@@ -146,18 +146,226 @@ fn launch_path(path: &Path, reveal: bool) -> Result<(), PlatformError> {
 
 #[cfg(windows)]
 fn launch_path(path: &Path, reveal: bool) -> Result<(), PlatformError> {
-    let mut command = if reveal {
-        let mut command = std::process::Command::new("explorer.exe");
-        command.arg(format!("/select,{}", path.display()));
-        command
-    } else {
-        let mut command = std::process::Command::new("cmd.exe");
-        command.arg("/c").arg("start").arg("").arg(path);
-        command
-    };
+    if reveal {
+        // 「在文件夹中显示」：
+        // 1) 第三方默认文件管理器兜底（#122，同 hub reveal_file.rs 的
+        //    platform_reveal_file）：OneCommander / Total Commander / Files
+        //    等只改 HKCR\Directory\shell\open\command、未挂 Explorer
+        //    Replacement 钩子的 FM 拦截不到 SHOpenFolderAndSelectItems——API
+        //    会直接拉起 Explorer 且返回成功，永远走不到回退；必须先探测，
+        //    命中即退化为「用第三方 FM 打开父目录」（不选中）。
+        // 2) Explorer 仍是默认：走标准 Shell API「打开父目录并选中」（见
+        //    sh_open_folder_and_select），失败回退 open 动词打开父目录，
+        //    保证至少有响应。
+        let dir = if path.is_dir() {
+            path.to_path_buf()
+        } else {
+            path.parent().unwrap_or(path).to_path_buf()
+        };
+        if default_dir_handler_is_third_party() {
+            tracing::debug!("reveal: third-party default file manager detected; opening dir");
+            return open_with_shell(&dir);
+        }
+        if !path.is_dir() && sh_open_folder_and_select(&path.to_string_lossy()) {
+            return Ok(());
+        }
+        tracing::debug!(
+            "reveal: SHOpenFolderAndSelectItems failed; falling back to ShellExecuteW open"
+        );
+        return open_with_shell(&dir);
+    }
+    open_with_shell(path)
+}
+
+/// 打开任意路径（文件走默认关联程序、目录走默认文件管理器）。
+///
+/// 与 hub `reveal_file.rs` 的 `platform_open_dir` 同一策略：优先直接调 Win32
+/// `ShellExecuteW`（"open" 默认 verb，双击的 API 本体，无 cmd 引号/元字符
+/// 解析风险）；失败才回退 `cmd /c start "" <path>`（start 内部同样走 open
+/// 关联；第一个空引号串是窗口标题，不能省）。
+#[cfg(windows)]
+fn open_with_shell(path: &Path) -> Result<(), PlatformError> {
+    use std::os::windows::process::CommandExt;
+
+    let text = path.to_string_lossy();
+    if shell_execute_open(&text) {
+        return Ok(());
+    }
+    tracing::debug!("ShellExecuteW failed; falling back to cmd /c start");
+    let mut command = std::process::Command::new("cmd.exe");
+    command.raw_arg(format!(r#"/c start "" "{text}""#));
     set_no_console_window(&mut command);
     command.spawn()?;
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 打开/定位的 Shell 调用与注册表探测：与 hub `reveal_file.rs` 同款实现的有意
+// 复制（crate 边界隔离），下列每个函数在 hub 都有同名对应，修改务必双份同步。
+// ---------------------------------------------------------------------------
+
+/// 直接调 Win32 `ShellExecuteW`（"open" 默认 verb）打开路径——微软官方的
+/// 「打开」调用（双击的 API 本体），系统按 open 动词关联解析默认处理程序。
+/// 与 `hub/src/reveal_file.rs` 的同名实现保持一致。
+/// 返回值 > 32 表示成功（Win32 约定）。
+#[cfg(windows)]
+fn shell_execute_open(path: &str) -> bool {
+    use windows_sys::Win32::UI::Shell::ShellExecuteW;
+    use windows_sys::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL;
+
+    let wide: Vec<u16> = path.encode_utf16().chain(std::iter::once(0)).collect();
+    let verb: Vec<u16> = "open".encode_utf16().chain(std::iter::once(0)).collect();
+    // SAFETY: wide/verb 均为有效的 NUL 结尾 UTF-16 缓冲，在调用期间存活；
+    // 其余参数按文档允许为空。
+    let h = unsafe {
+        ShellExecuteW(
+            std::ptr::null_mut(),
+            verb.as_ptr(),
+            wide.as_ptr(),
+            std::ptr::null(),
+            std::ptr::null(),
+            SW_SHOWNORMAL,
+        )
+    };
+    h as usize > 32
+}
+
+/// 标准 Shell API：打开 `path` 所在父目录并选中 `path`（文件/目录皆可）。
+///
+/// `SHOpenFolderAndSelectItems` 是 Windows Shell 的标准「定位到文件夹视图」
+/// 调用，不硬编码 explorer.exe——文件夹视图由系统 Shell 打开。用 cidl=0 的
+/// 简写形式：`pidlFolder` 直接指向要选中的项，系统自动打开其父目录并选中
+/// 该项（见 MSDN 备注）。实现与 CLaunch 的 `openParentFolder` 同款：
+/// `SHParseDisplayName` 解析绝对 PIDL + `CoTaskMemFree` 释放 + 防御性 COM
+/// 初始化；失败返回 false，调用方回退为 open 动词打开父目录。
+///
+/// **同步注意**：本函数与 hub `reveal_file.rs` 的同名函数是有意复制的两份
+/// （crate 边界隔离），修改任一份务必同步另一份。
+///
+/// 文档要求先 CoInitialize：本函数运行在 RPC 处理线程上，这里做防御性
+/// 初始化——`hr < 0` 视为失败；S_OK/S_FALSE 都会取得本线程初始化引用，
+/// 结尾须配对 `CoUninitialize`。
+#[cfg(windows)]
+fn sh_open_folder_and_select(path: &str) -> bool {
+    use windows_sys::Win32::System::Com::{CoInitializeEx, CoTaskMemFree, CoUninitialize};
+    use windows_sys::Win32::UI::Shell::{SHOpenFolderAndSelectItems, SHParseDisplayName};
+
+    /// `COINIT_APARTMENTTHREADED`。
+    const COINIT_APARTMENTTHREADED: u32 = 2;
+
+    let wide: Vec<u16> = path.encode_utf16().chain(std::iter::once(0)).collect();
+    // SAFETY: wide 为有效的 NUL 结尾 UTF-16 缓冲，在调用期间存活；其余参数
+    // 按文档允许为空。
+    let hr = unsafe { CoInitializeEx(std::ptr::null(), COINIT_APARTMENTTHREADED) };
+    if hr < 0 {
+        tracing::debug!(hr = format!("{hr:#x}"), "CoInitializeEx failed");
+        return false;
+    }
+
+    let mut pidl = std::ptr::null_mut();
+    // SAFETY: wide 存活于调用期间；ppidl 接收输出，sfgaoIn/psfgaoOut 传空。
+    // pbc 为 *mut c_void，须用 null_mut()——Rust 无 *const → *mut 隐式转换。
+    let hr_parse = unsafe {
+        SHParseDisplayName(
+            wide.as_ptr(),
+            std::ptr::null_mut(),
+            &mut pidl,
+            0,
+            std::ptr::null_mut(),
+        )
+    };
+    if hr_parse < 0 || pidl.is_null() {
+        tracing::debug!(hr = format!("{hr_parse:#x}"), "SHParseDisplayName failed");
+        // SAFETY: 与上方取得初始化引用的 CoInitializeEx 配对。
+        unsafe { CoUninitialize() };
+        return false;
+    }
+
+    // cidl=0 简写：pidlFolder 直接指向要选中的项，系统打开其父目录并选中它。
+    // SAFETY: pidl 为 SHParseDisplayName 成功返回的有效 PIDL，调用后立即释放。
+    let hr_select = unsafe { SHOpenFolderAndSelectItems(pidl, 0, std::ptr::null(), 0) };
+    // SAFETY: 释放 SHParseDisplayName 按 COM 分配器返回的 PIDL。
+    unsafe { CoTaskMemFree(pidl.cast()) };
+    // SAFETY: 与上方取得初始化引用的 CoInitializeEx 配对。
+    unsafe { CoUninitialize() };
+    if hr_select < 0 {
+        tracing::debug!(
+            hr = format!("{hr_select:#x}"),
+            "SHOpenFolderAndSelectItems failed"
+        );
+        return false;
+    }
+    true
+}
+
+/// Windows：系统「打开目录」的默认处理程序是否已被替换成第三方文件管理器。
+///
+/// 读取 `HKCR\Directory\shell\<默认 verb>\command` 并解析其可执行文件名。
+/// 非 `explorer.exe` 时返回 `true`；键缺失、读取失败或仍是 Explorer 时返回
+/// `false`（保留 Shell API 的选中体验）。`<默认 verb>` 取 `Directory\shell`
+/// 的默认值，为空或 `none` 时回退到 `open`（第三方替换的常用写法）。只改了
+/// 此键的第三方 FM（OneCommander 等）拦截不到 `SHOpenFolderAndSelectItems`，
+/// 必须靠它兜底。与 hub `reveal_file.rs` 的同名函数保持一致。
+#[cfg(windows)]
+fn default_dir_handler_is_third_party() -> bool {
+    use winreg::RegKey;
+    use winreg::enums::HKEY_CLASSES_ROOT;
+
+    let hkcr = RegKey::predef(HKEY_CLASSES_ROOT);
+    let Ok(shell) = hkcr.open_subkey(r"Directory\shell") else {
+        return false;
+    };
+    let verb = shell.get_value::<String, _>("").unwrap_or_default();
+    let verb = verb.trim();
+    let verb = if verb.is_empty() || verb.eq_ignore_ascii_case("none") {
+        "open"
+    } else {
+        verb
+    };
+    let Ok(cmd_key) = hkcr.open_subkey(format!(r"Directory\shell\{verb}\command")) else {
+        return false;
+    };
+    let Ok(cmd) = cmd_key.get_value::<String, _>("") else {
+        return false;
+    };
+    match exe_basename(&cmd) {
+        Some(name) => !name.eq_ignore_ascii_case("explorer.exe"),
+        None => false,
+    }
+}
+
+/// 返回裸路径字符串中首个（不区分大小写）以 `.exe` 结尾的字节偏移；找不到
+/// 时返回 `None`。`.exe` 全为 ASCII，`to_ascii_lowercase` 不改变字节长度
+/// 与 UTF-8 边界，返回的偏移量可直接用于原字符串按字节切片。
+#[cfg(windows)]
+fn find_exe_end(cmd: &str) -> Option<usize> {
+    cmd.to_ascii_lowercase().find(".exe").map(|idx| idx + 4)
+}
+
+/// 从注册表 shell command 字符串解析出可执行文件的文件名（basename）。
+/// 支持带引号路径（`"C:\..\fm.exe" "%1"`）与裸路径
+/// (`%SystemRoot%\Explorer.exe /idlist,...`)；返回 `None` 表示无法解析。
+#[cfg(windows)]
+fn exe_basename(cmd: &str) -> Option<String> {
+    let cmd = cmd.trim();
+    let exe = if let Some(rest) = cmd.strip_prefix('"') {
+        rest.split('"').next().unwrap_or(rest)
+    } else {
+        // 裸路径可能含空格且未加引号写入注册表（如部分第三方文件管理器的安装
+        // 程序），不能简单按空白切分；取字符串中首个（不区分大小写）以
+        // ".exe" 结尾的位置，把它之前的内容整体当作可执行文件路径，大小写
+        // 按原样保留。找不到 ".exe" 时退回按空白切分。
+        match find_exe_end(cmd) {
+            Some(end) => &cmd[..end],
+            None => cmd.split_whitespace().next().unwrap_or(cmd),
+        }
+    };
+    let base = exe.rsplit(['\\', '/']).next().unwrap_or(exe).trim();
+    if base.is_empty() {
+        None
+    } else {
+        Some(base.to_string())
+    }
 }
 
 #[cfg(windows)]

--- a/native/hub/Cargo.toml
+++ b/native/hub/Cargo.toml
@@ -69,9 +69,10 @@ reqwest = { version = "0.12", features = ["stream", "native-tls", "cookies", "js
 # 系统调用：SetFileInformationByHandle（文件预分配真正保留 NTFS 物理簇）
 # 固定 0.59：0.61 引入 windows-link(raw-dylib)，与 cdylib 构建在 CI 上不兼容
 # Win32_UI_Shell + WindowsAndMessaging：ShellExecuteW（打开文件/目录走系统关联，等价双击，见 reveal_file.rs）
+# Win32_UI_Shell_Common：SHParseDisplayName / SHOpenFolderAndSelectItems（ITEMIDLIST 类型，见 reveal_file.rs）
 # Win32_System_DataExchange + Memory + Foundation：CF_HDROP 剪贴板（右键「复制文件」，见 clipboard_file.rs）
 # Win32_System_Com：CoCreateInstance/IPersistFile（快捷方式图标重写，见 shortcut_icon.rs）
-windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_DataExchange", "Win32_System_Memory", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
+windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_DataExchange", "Win32_System_Memory", "Win32_UI_Shell", "Win32_UI_Shell_Common", "Win32_UI_WindowsAndMessaging"] }
 # ZIP 解析：用于 bootstrap fluxdown_updater.exe（从下载的 ZIP 中提取，兼容从旧版升级的用户）
 zip = { version = "2", default-features = false, features = ["deflate"] }
 

--- a/native/hub/src/reveal_file.rs
+++ b/native/hub/src/reveal_file.rs
@@ -13,7 +13,7 @@
 /// 平台默认行为（无模板时）：
 /// | 平台    | 文件                                                   | 目录                          |
 /// |---------|--------------------------------------------------------|-------------------------------|
-/// | Windows | 第三方默认 FM→打开父目录，否则 `explorer.exe /select,"path"`     | `cmd /c start "" "dir"`       |
+/// | Windows | 第三方默认 FM → 仅打开父目录；否则 `SHOpenFolderAndSelectItems`（选中），失败回退 open 动词 | `ShellExecuteW("open", dir)`  |
 /// | macOS   | `open -R path`                                         | `open path`                   |
 /// | Linux   | D-Bus `FileManager1.ShowItems`，失败 fallback xdg-open | `xdg-open dir`                |
 pub fn reveal(path: &str, tpl: &str) {
@@ -140,6 +140,71 @@ fn shell_execute_open(path: &str) -> bool {
         )
     };
     h as usize > 32
+}
+
+/// 标准 Shell API：打开 `path` 所在父目录并选中 `path`（文件/目录皆可）。
+///
+/// `SHOpenFolderAndSelectItems` 是 Windows Shell 的标准「定位到文件夹视图」
+/// 调用，不硬编码 explorer.exe——文件夹视图由系统 Shell 打开。用 cidl=0 的
+/// 简写形式：`pidlFolder` 直接指向要选中的项，系统自动打开其父目录并选中
+/// 该项（见 MSDN 备注）。实现与 CLaunch 的 `openParentFolder` 同款：
+/// `SHParseDisplayName` 解析绝对 PIDL + `CoTaskMemFree` 释放 + 防御性 COM
+/// 初始化；失败返回 false，调用方回退为 open 动词打开父目录。
+///
+/// **同步注意**：本函数与 agent `src/platform/mod.rs` 的同名函数是有意复制
+/// 的两份（crate 边界隔离），修改任一份务必同步另一份。
+///
+/// 文档要求先 CoInitialize：本函数运行在 spawn_blocking/NMH 线程上，这里
+/// 做防御性初始化（同 `shortcut_icon.rs` 的模式）——`hr < 0` 视为失败；
+/// S_OK/S_FALSE 都会取得本线程初始化引用，结尾须配对 `CoUninitialize`。
+#[cfg(target_os = "windows")]
+fn sh_open_folder_and_select(path: &str) -> bool {
+    use windows_sys::Win32::System::Com::{CoInitializeEx, CoTaskMemFree, CoUninitialize};
+    use windows_sys::Win32::UI::Shell::{SHOpenFolderAndSelectItems, SHParseDisplayName};
+
+    /// `COINIT_APARTMENTTHREADED`。
+    const COINIT_APARTMENTTHREADED: u32 = 2;
+
+    let wide: Vec<u16> = path.encode_utf16().chain(std::iter::once(0)).collect();
+    // SAFETY: wide 为有效的 NUL 结尾 UTF-16 缓冲，在调用期间存活；其余参数
+    // 按文档允许为空。
+    let hr = unsafe { CoInitializeEx(std::ptr::null(), COINIT_APARTMENTTHREADED) };
+    if hr < 0 {
+        crate::logger::log_info!("[reveal] CoInitializeEx failed: {hr:#x}");
+        return false;
+    }
+
+    let mut pidl = std::ptr::null_mut();
+    // SAFETY: wide 存活于调用期间；ppidl 接收输出，sfgaoIn/psfgaoOut 传空。
+    // pbc 为 *mut c_void，须用 null_mut()——Rust 无 *const → *mut 隐式转换。
+    let hr_parse = unsafe {
+        SHParseDisplayName(
+            wide.as_ptr(),
+            std::ptr::null_mut(),
+            &mut pidl,
+            0,
+            std::ptr::null_mut(),
+        )
+    };
+    if hr_parse < 0 || pidl.is_null() {
+        crate::logger::log_info!("[reveal] SHParseDisplayName failed: {hr_parse:#x}");
+        // SAFETY: 与上方取得初始化引用的 CoInitializeEx 配对。
+        unsafe { CoUninitialize() };
+        return false;
+    }
+
+    // cidl=0 简写：pidlFolder 直接指向要选中的项，系统打开其父目录并选中它。
+    // SAFETY: pidl 为 SHParseDisplayName 成功返回的有效 PIDL，调用后立即释放。
+    let hr_select = unsafe { SHOpenFolderAndSelectItems(pidl, 0, std::ptr::null(), 0) };
+    // SAFETY: 释放 SHParseDisplayName 按 COM 分配器返回的 PIDL。
+    unsafe { CoTaskMemFree(pidl.cast()) };
+    // SAFETY: 与上方取得初始化引用的 CoInitializeEx 配对。
+    unsafe { CoUninitialize() };
+    if hr_select < 0 {
+        crate::logger::log_info!("[reveal] SHOpenFolderAndSelectItems failed: {hr_select:#x}");
+        return false;
+    }
+    true
 }
 
 /// 常见压缩包扩展名（含复合扩展名 .tar.gz 等——只需匹配末段即可）。
@@ -313,47 +378,50 @@ fn shell_quote(s: &str) -> String {
 }
 
 // ---------------------------------------------------------------------------
-// 平台默认：reveal 文件（父目录 + 选中）
+// 平台默认：reveal 文件（标准 Shell API 选中，失败回退 open 动词）
 // ---------------------------------------------------------------------------
 
 #[cfg(target_os = "windows")]
 fn platform_reveal_file(path: &str) {
-    use std::os::windows::process::CommandExt;
-
-    // 若用户把"打开目录"的默认处理程序替换成第三方文件管理器（改
-    // HKCR\Directory\shell\open\command，OneCommander/Directory Opus/Total
-    // Commander/Files 等的统一机制），尊重该设置：用其打开父目录。Windows 的
-    // /select（打开目录并选中文件）是 Explorer 私有 verb，第三方 FM 普遍不支持，
-    // 也无通用 API 可重定向，故退化为"打开父目录"。想在第三方 FM 里精确选中的
-    // 用户可在设置里配置 reveal 文件命令模板（reveal() 已优先于此处理）。
+    let dir = std::path::Path::new(path)
+        .parent()
+        .map(|d| d.to_string_lossy().into_owned())
+        .unwrap_or_else(|| path.to_string());
+    // 第三方文件管理器兜底（#122）：OneCommander / Total Commander / Files
+    // 等只改 HKCR\Directory\shell\open\command、未挂 Explorer Replacement
+    // 钩子的 FM 拦截不到 SHOpenFolderAndSelectItems——API 会直接拉起
+    // Explorer 且返回成功，永远走不到下面的回退。必须先探测，命中即退化为
+    // 「用第三方 FM 打开父目录」（不选中；想精确选中的用户可配置 reveal
+    // 命令模板，reveal() 已优先于本函数）。
     if default_dir_handler_is_third_party() {
-        let dir = std::path::Path::new(path)
-            .parent()
-            .map(|d| d.to_string_lossy().into_owned())
-            .unwrap_or_else(|| path.to_string());
         crate::logger::log_info!(
-            "[reveal] third-party default file manager detected; opening parent dir instead of explorer /select"
+            "[reveal] third-party default file manager detected; opening parent dir instead of shell select"
         );
         platform_open_dir(&dir);
         return;
     }
-
-    // Explorer 仍是默认：用 /select 打开父目录并选中文件。
-    let arg = format!(r#"/select,"{}""#, path);
-    if let Err(e) = std::process::Command::new("explorer.exe")
-        .raw_arg(&arg)
-        .spawn()
-    {
-        crate::logger::log_info!("[reveal] explorer /select failed: {e}");
+    // Explorer 仍是默认：走标准 Shell API「打开父目录并选中」，由系统 Shell
+    // 打开文件夹视图并选中目标，不硬编码 explorer.exe（见
+    // sh_open_folder_and_select）；失败时回退 open 动词打开父目录（不选中），
+    // 保证至少有响应。
+    if sh_open_folder_and_select(path) {
+        return;
     }
+    crate::logger::log_info!(
+        "[reveal] SHOpenFolderAndSelectItems failed; falling back to open verb"
+    );
+    platform_open_dir(&dir);
 }
 
-/// Windows：系统"打开目录"的默认处理程序是否已被替换成第三方文件管理器。
+/// Windows：系统「打开目录」的默认处理程序是否已被替换成第三方文件管理器。
 ///
 /// 读取 `HKCR\Directory\shell\<默认 verb>\command` 并解析其可执行文件名。
 /// 非 `explorer.exe` 时返回 `true`；键缺失、读取失败或仍是 Explorer 时返回
-/// `false`（保留 `/select` 的选中体验）。`<默认 verb>` 取 `Directory\shell`
-/// 的默认值，为空或 `none` 时回退到 `open`（第三方替换的常用写法）。
+/// `false`（保留 Shell API 的选中体验）。`<默认 verb>` 取 `Directory\shell`
+/// 的默认值，为空或 `none` 时回退到 `open`（第三方替换的常用写法）。只改了
+/// 此键的第三方 FM（OneCommander 等）拦截不到 `SHOpenFolderAndSelectItems`，
+/// 必须靠它兜底；做过 Explorer Replacement 的 FM（Directory Opus 等）两边
+/// 都能正确工作，本探测对它们返回 `false` 不影响效果。
 #[cfg(target_os = "windows")]
 fn default_dir_handler_is_third_party() -> bool {
     use winreg::RegKey;
@@ -463,14 +531,18 @@ fn platform_reveal_file(path: &str) {
 // 平台默认：打开目录（不选中）
 // ---------------------------------------------------------------------------
 //
-// Windows: 用 `cmd /c start "" "dir"` 走 ShellExecute 关联，尊重用户在
-// `HKCR\Folder\shell\open\command` 注册的默认 FM；直接 explorer.exe <dir>
-// 会强制使用 Explorer。
+// Windows: ShellExecuteW("open") —— 微软官方的"打开"调用（双击的 API 本体），
+// 系统按 Directory/Folder 的 open 动词关联解析默认文件管理器；`cmd /c start`
+// 仅作 ShellExecuteW 失败时的回退（start 内部同样走该关联）。
 // macOS: open <dir> 走 LaunchServices，尊重 `public.folder` 默认 handler。
 // Linux: xdg-open 走 mimeapps.list 的 inode/directory 默认。
 
 #[cfg(target_os = "windows")]
 fn platform_open_dir(dir: &str) {
+    if shell_execute_open(dir) {
+        return;
+    }
+    crate::logger::log_info!("[reveal] ShellExecuteW failed; falling back to cmd /c start");
     use std::os::windows::process::CommandExt;
     // start 的第一个引号串是窗口标题，必须保留为空，否则 cmd 会把目录路径
     // 当成标题而打开新 cmd 窗口。

--- a/native/hub/src/signals/mod.rs
+++ b/native/hub/src/signals/mod.rs
@@ -179,7 +179,11 @@ pub struct BatchControlTask {
 pub struct RequestAllTasks {}
 
 /// Reveal a file in the native file manager and select it.
-/// Windows: explorer.exe /select,"path" via raw_arg (bypasses argument escaping).
+/// Windows: SHOpenFolderAndSelectItems (standard Shell API) opens the parent
+/// folder and selects the item; on failure falls back to ShellExecuteW("open")
+/// on the parent directory. If the default directory handler is a third-party
+/// file manager, opens the parent directory directly (FMs that only override
+/// HKCR\Directory\shell\open\command cannot intercept the Shell API).
 /// macOS/Linux: handled on the Dart side; this signal is Windows-only.
 #[derive(Deserialize, DartSignal)]
 pub struct RevealFile {


### PR DESCRIPTION
使用标准 Shell API 解决#122 部分改善 #397 

