### PR TITLE
feat(plugin): add onCancel hook for cancelled tasks

### DIFF
--- a/native/engine/src/download_manager.rs
+++ b/native/engine/src/download_manager.rs
@@ -1993,7 +1993,8 @@ impl DownloadManager {
                 "[plugin-resolve] task {} variant selection cancelled by user, cancelling task",
                 task_id
             );
-            self.cancel_task(&task_id).await;
+            self.cancel_task_with_reason(&task_id, "variant_selection_cancelled")
+                .await;
             return;
         }
         // 任务已从 DB 删除（兜底；delete_task 亦已清 pending_resolve）→ 放弃再入。
@@ -6689,6 +6690,25 @@ impl DownloadManager {
     }
 
     pub async fn cancel_task(&mut self, task_id: &str) {
+        self.cancel_task_with_reason(task_id, "user_cancelled")
+            .await;
+    }
+
+    /// 取消任务并携带插件 Hook 原因。公开入口保留默认的
+    /// `user_cancelled` 语义；内部取消场景可传递更具体的原因。
+    #[allow(unused_variables)]
+    async fn cancel_task_with_reason(&mut self, task_id: &str, reason: &str) {
+        // 先读取终态和 URL：取消可能来自尚未启动的队列项，也可能来自变体
+        // 选择窗口。仅首次从非终态进入 cancelled 才发 onCancel，避免重复
+        // 调用 cancel_task 造成重复通知。
+        let task_before = self.db.load_task_by_id(task_id).await.ok().flatten();
+        let should_notify_cancel = task_before
+            .as_ref()
+            .is_some_and(|task| task.status != 3 && task.status != 4);
+        let cancel_url = task_before
+            .as_ref()
+            .map(|task| task.url.clone())
+            .unwrap_or_default();
         // 清除自动重试计数，与 delete_task / resume_task 对齐。取消是用户的
         // 明确意图，必须从自动重试状态中移除，使后续 create/resume 干净起步。
         self.auto_retry_counts.remove(task_id);
@@ -6765,6 +6785,19 @@ impl DownloadManager {
                 .map(|t| t.seeding_time_secs)
                 .unwrap_or_default(),
         });
+
+        // 插件通知：取消不改变任务状态，也不等待脚本执行；Hook 异常/超时由
+        // PluginManager 按通知平面约定吞掉。URL 取取消前任务记录，保证变体
+        // 选择取消仍能拿到分享链接（任务尚未应用解析结果）。
+        #[cfg(feature = "plugins")]
+        if should_notify_cancel && let Some(pm) = &self.plugin_manager {
+            pm.notify(crate::plugin::PluginEvent::Cancel {
+                task_id: task_id.to_string(),
+                url: cancel_url,
+                reason: Some(reason.to_string()),
+            })
+            .await;
+        }
 
         // A slot freed up — try to start queued tasks.
         self.drain_queue().await;

--- a/native/engine/src/plugin/manifest.rs
+++ b/native/engine/src/plugin/manifest.rs
@@ -184,7 +184,7 @@ pub struct PluginManifest {
 }
 
 /// 合法事件名（manifest `hooks.events`）。
-pub const VALID_EVENTS: [&str; 4] = ["onStart", "onError", "onDone", "onMetaProbed"];
+pub const VALID_EVENTS: [&str; 5] = ["onStart", "onError", "onDone", "onMetaProbed", "onCancel"];
 
 /// ffmpeg 能力权限名（manifest `permissions`）。
 pub const PERMISSION_FFMPEG: &str = "ffmpeg";
@@ -568,6 +568,15 @@ mod tests {
                 "resolvers":[{"match":{"urls":["*://x.com/*"]},"entry":"r.js"}],
                 "settings":[{"key":"q","title":"Q","type":"string","widget":"select",
                              "options":[{"value":"a","label":"A"}],"default":"a"}]}"#,
+        );
+        assert!(m.validate().is_ok());
+    }
+
+    #[test]
+    fn on_cancel_event_is_valid() {
+        let m = parse_ok(
+            r#"{"identity":"a@b","name":"N","version":"1.0.0",
+                "hooks":{"entry":"h.js","events":["onCancel"]}}"#,
         );
         assert!(m.validate().is_ok());
     }

--- a/native/engine/src/plugin/mod.rs
+++ b/native/engine/src/plugin/mod.rs
@@ -5,7 +5,7 @@
 //!    实际发起下载协议判定之前、且 off-actor（见 [`crate::download_manager`] 的
 //!    off-actor resolve 插桩）；命中后失败 fail-closed（进 status=4，绝不静默把网页
 //!    HTML 当视频保存），并暴露「忽略插件重试」逃生舱。
-//! 2. **通知平面**：onStart/onDone/onError/onMetaProbed **全部 fire-and-forget**
+//! 2. **通知平面**：onStart/onDone/onError/onMetaProbed/onCancel **全部 fire-and-forget**
 //!    （失败仅记日志、超时、`try_acquire` 不阻塞，绝不影响任务状态）。
 //!
 //! 本模块仅在 `plugins` feature 开启时编译（desktop/server），mobile 关闭以免背 JS

--- a/native/engine/src/plugin/runtime.rs
+++ b/native/engine/src/plugin/runtime.rs
@@ -35,7 +35,7 @@ pub struct PluginScript {
 pub enum PluginEntryKind {
     /// resolver 入口：`globalThis.resolve`。
     Resolve,
-    /// hook 入口：`globalThis.onStart/onError/onDone/onMetaProbed`（由 event 决定）。
+    /// hook 入口：`globalThis.onStart/onError/onDone/onMetaProbed/onCancel`（由 event 决定）。
     Hook,
 }
 
@@ -209,6 +209,13 @@ pub enum PluginEvent {
         file_name: String,
         total_bytes: i64,
     },
+    #[serde(rename = "onCancel")]
+    Cancel {
+        task_id: String,
+        url: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reason: Option<String>,
+    },
 }
 
 impl PluginEvent {
@@ -219,6 +226,7 @@ impl PluginEvent {
             PluginEvent::Error { .. } => "onError",
             PluginEvent::Done { .. } => "onDone",
             PluginEvent::MetaProbed { .. } => "onMetaProbed",
+            PluginEvent::Cancel { .. } => "onCancel",
         }
     }
 
@@ -233,7 +241,8 @@ impl PluginEvent {
             PluginEvent::Start { url, .. }
             | PluginEvent::Error { url, .. }
             | PluginEvent::Done { url, .. }
-            | PluginEvent::MetaProbed { url, .. } => url,
+            | PluginEvent::MetaProbed { url, .. }
+            | PluginEvent::Cancel { url, .. } => url,
         }
     }
 }
@@ -611,6 +620,26 @@ mod tests {
             "must not emit snake_case task_id"
         );
         assert!(v.get("file_path").is_none());
+
+        let cancel = PluginEvent::Cancel {
+            task_id: "t3".into(),
+            url: "https://example.com/share".into(),
+            reason: Some("variant_selection_cancelled".into()),
+        };
+        let cv: serde_json::Value = serde_json::to_value(&cancel).expect("serialize");
+        assert_eq!(cv["event"], "onCancel");
+        assert_eq!(cv["taskId"], "t3");
+        assert_eq!(cv["url"], "https://example.com/share");
+        assert_eq!(cv["reason"], "variant_selection_cancelled");
+
+        let cancel_without_reason = PluginEvent::Cancel {
+            task_id: "t4".into(),
+            url: "https://example.com/share2".into(),
+            reason: None,
+        };
+        let crv: serde_json::Value =
+            serde_json::to_value(&cancel_without_reason).expect("serialize");
+        assert!(crv.get("reason").is_none());
 
         let meta = PluginEvent::MetaProbed {
             task_id: "t2".into(),

--- a/website/src/content/docs/en/plugins/api-reference.md
+++ b/website/src/content/docs/en/plugins/api-reference.md
@@ -44,7 +44,7 @@ After resolution, FluxDown re-examines the *resolved* URL to pick the protocol e
 
 Error behavior is fail-closed: an exception, timeout, invalid return value, or an uninstalled/disabled plugin all put the task into the error state. The original URL is never silently downloaded.
 
-### `onStart(ctx)` / `onDone(ctx)` / `onError(ctx)` / `onMetaProbed(ctx)`
+### `onStart(ctx)` / `onDone(ctx)` / `onError(ctx)` / `onMetaProbed(ctx)` / `onCancel(ctx)`
 
 Notification hooks. All receive `{ event, taskId, url }` plus event-specific fields:
 
@@ -54,8 +54,13 @@ Notification hooks. All receive `{ event, taskId, url }` plus event-specific fie
 | `onError` | `message` — the task's error text |
 | `onDone` | `filePath` — absolute path of the finished file; `audioPath` — for track-pair tasks (separate video+audio streams) where muxing failed, the absolute path of the standalone audio file (`<stem>.audio.m4a`); `null` for single-file results (including successful mux); `muxed` — whether a track-pair task was successfully merged into a single file, always `false` for non-track-pair tasks |
 | `onMetaProbed` | `fileName`, `totalBytes` — probe results |
+| `onCancel` | `reason` — optional cancellation reason (for example, `variant_selection_cancelled` or `user_cancelled`) |
 
 `url` is always the task's original URL, and it's what the manifest's `hooks.match.urls` filter is applied to.
+
+`onCancel` is mutually exclusive with `onDone` and `onError`, and fires at most once per task.
+User cancellation uses `reason: "user_cancelled"`; closing the variant selection dialog uses
+`reason: "variant_selection_cancelled"`. The cancellation hook cannot retry or change task state.
 
 Hooks are fire-and-forget: exceptions and timeouts are logged and swallowed, and if the plugin runtime is saturated the notification is dropped. Nothing a hook does can change the task — with one exception, `flux.task.requestRetry`, valid only inside `onError`.
 

--- a/website/src/content/docs/en/plugins/manifest.md
+++ b/website/src/content/docs/en/plugins/manifest.md
@@ -60,7 +60,7 @@ A plugin may declare a resolver, hooks, or both. A manifest with neither is vali
 | Field | Required | Rules |
 |---|---|---|
 | `entry` | yes | Script file, safe relative path. Must define a global function per subscribed event. |
-| `events` | yes | Non-empty subset of `onStart`, `onError`, `onDone`, `onMetaProbed`. Anything else is rejected. |
+| `events` | yes | Non-empty subset of `onStart`, `onError`, `onDone`, `onMetaProbed`, `onCancel`. Anything else is rejected. |
 | `match` | no | Optional URL filter, same pattern rules. If present, `urls` must be non-empty. Omitted = the hooks fire for every task. |
 
 Caveat: if the same plugin also declares a resolver, `onMetaProbed` never fires for its tasks — resolver tasks skip the metadata probe entirely. FluxDown logs a warning if you subscribe to it anyway.

--- a/website/src/content/docs/en/plugins/overview.md
+++ b/website/src/content/docs/en/plugins/overview.md
@@ -10,7 +10,7 @@ FluxDown plugins are small JavaScript programs that hook into the download pipel
 Plugins can do exactly two things:
 
 1. **Resolve URLs** — rewrite a task's URL before the download starts. This is how you turn a share-page link (a video page, a file-hosting page) into the actual direct download link. Declared under `resolvers` in the manifest; the script exports a global `resolve(ctx)` function.
-2. **React to task events** — get notified when a task starts, finishes, fails, or has its metadata probed. Declared under `hooks`; the script exports global `onStart` / `onDone` / `onError` / `onMetaProbed` functions.
+2. **React to task events** — get notified when a task starts, finishes, fails, is cancelled, or has its metadata probed. Declared under `hooks`; the script exports global `onStart` / `onDone` / `onError` / `onCancel` / `onMetaProbed` functions.
 
 Plugins **cannot** create tasks, read arbitrary files, or touch the UI. They talk to the outside world only through the `flux.*` API (HTTP fetch, key-value storage, logging, retry requests) — see the [API reference](/docs/en/plugins/api-reference/).
 

--- a/website/src/content/docs/zh/plugins/api-reference.md
+++ b/website/src/content/docs/zh/plugins/api-reference.md
@@ -45,7 +45,7 @@ sourceHash: "4501af5b1d55"
 
 错误行为是 fail-closed：抛异常、超时、返回值不合法、插件已卸载或被禁用，任务都进入错误状态。原始 URL 绝不会被悄悄下载。
 
-### `onStart(ctx)` / `onDone(ctx)` / `onError(ctx)` / `onMetaProbed(ctx)`
+### `onStart(ctx)` / `onDone(ctx)` / `onError(ctx)` / `onMetaProbed(ctx)` / `onCancel(ctx)`
 
 通知钩子。都会收到 `{ event, taskId, url }`，再加各自的字段：
 
@@ -55,8 +55,13 @@ sourceHash: "4501af5b1d55"
 | `onError` | `message`——任务的错误文本 |
 | `onDone` | `filePath`——完成文件的绝对路径；`audioPath`——轨对任务（视频+音频离散轨）mux 失败降级时独立音频文件（`<主干名>.audio.m4a`）的绝对路径，单文件产物（含 mux 成功）为 `null`；`muxed`——轨对任务是否已成功合并为单文件，非轨对任务恒 `false` |
 | `onMetaProbed` | `fileName`、`totalBytes`——探测结果 |
+| `onCancel` | `reason`——取消原因（可选；例如 `variant_selection_cancelled`、`user_cancelled`） |
 
 `url` 恒为任务的原始 URL，manifest 里 `hooks.match.urls` 也是拿它过滤的。
+
+`onCancel` 与 `onDone`、`onError` 互斥；同一任务最多触发一次。用户取消下载时
+`reason` 为 `user_cancelled`，在画质/格式变体选择窗口点取消时为
+`variant_selection_cancelled`。取消钩子不能重试或改变任务状态。
 
 钩子发出后不管结果：异常和超时只记日志然后吞掉，插件运行时忙不过来时通知直接丢弃。钩子做的任何事都改变不了任务——唯一例外是 `flux.task.requestRetry`，且只在 `onError` 里有效。
 

--- a/website/src/content/docs/zh/plugins/manifest.md
+++ b/website/src/content/docs/zh/plugins/manifest.md
@@ -61,7 +61,7 @@ sourceHash: "b8cae49fcfee"
 | 字段 | 必填 | 规则 |
 |---|---|---|
 | `entry` | 是 | 脚本文件，安全相对路径。按订阅的事件各定义一个全局函数。 |
-| `events` | 是 | 非空，只能取 `onStart`、`onError`、`onDone`、`onMetaProbed`，其余一律拒绝。 |
+| `events` | 是 | 非空，只能取 `onStart`、`onError`、`onDone`、`onMetaProbed`、`onCancel`，其余一律拒绝。 |
 | `match` | 否 | 可选的 URL 过滤器，pattern 规则同上；存在时 `urls` 不能为空。省略 = 所有任务都触发。 |
 
 注意：同一插件如果还声明了 resolver，`onMetaProbed` 对它的任务永远不触发——带 resolver 的任务直接跳过元数据探测。你照订阅的话，FluxDown 会记一条警告日志。

--- a/website/src/content/docs/zh/plugins/overview.md
+++ b/website/src/content/docs/zh/plugins/overview.md
@@ -11,7 +11,7 @@ FluxDown 插件是挂进下载流程的小段 JavaScript 程序。一个插件�
 插件只能做两类事：
 
 1. **解析 URL（resolver）**——在下载开始前改写任务的 URL。典型用途：把一个分享页链接（视频页、网盘页）变成真正的直链。在 manifest 的 `resolvers` 里声明，脚本导出一个全局 `resolve(ctx)` 函数。
-2. **响应任务事件（hooks）**——任务开始、完成、出错、探测到元数据时收到通知。在 `hooks` 里声明，脚本导出全局的 `onStart` / `onDone` / `onError` / `onMetaProbed` 函数。
+2. **响应任务事件（hooks）**——任务开始、完成、出错、取消、探测到元数据时收到通知。在 `hooks` 里声明，脚本导出全局的 `onStart` / `onDone` / `onError` / `onCancel` / `onMetaProbed` 函数。
 
 插件**不能**创建任务、不能读任意文件、不能操作界面。它和外界打交道只有 `flux.*` 这一套接口（HTTP 请求、键值存储、日志、请求重试），见 [API 参考](/docs/zh/plugins/api-reference/)。
 


### PR DESCRIPTION
## Summary
- add the `onCancel` plugin hook and manifest event
- emit cancellation notifications once per task with an optional reason
- report `variant_selection_cancelled` when variant selection is dismissed
- document the event and cancellation semantics in English and Chinese

Closes #593

## Verification
- `cargo fmt --all -- --check`
- `cargo check -p fluxdown_engine --features plugins`
- `cargo test -p fluxdown_engine --features plugins --lib plugin::` (62 passed)
- full library run: 924 passed, 2 unrelated pre-existing failures (`db::tests::exclusive_open_rejects_second_writer_until_guard_drops`, `cdn::tests::probe_alive_filters_dead_candidates`)