### PR TITLE
macOS 搜索快捷键徽章显示 ⌘F (#554)

### DIFF
--- a/lib/src/widgets/header_bar.dart
+++ b/lib/src/widgets/header_bar.dart
@@ -357,7 +357,7 @@ class HeaderBarState extends State<HeaderBar> {
                               border: Border.all(color: c.border, width: 1),
                             ),
                             child: Text(
-                              'Ctrl+F',
+                              Platform.isMacOS ? '⌘F' : 'Ctrl+F',
                               style: TextStyle(
                                 fontSize: 10,
                                 color: c.textMuted,


### PR DESCRIPTION
## 改动
- `lib/src/widgets/header_bar.dart`：主页搜索框旁快捷键徽章按平台切换文案，macOS 显示 `⌘F`，Windows/Linux 保持 `Ctrl+F`
- 与 `lib/src/pages/home_page.dart` 中已有的 `Platform.isMacOS` 快捷键判定写法保持一致
- 快捷键文案按 AGENTS.md 属 i18n 豁免，未新增 i18n 键

## 验证
- `dart analyze lib/src/widgets/header_bar.dart` → No issues found!
- `dart format lib/src/widgets/header_bar.dart` → 无格式变更

Closes #554