### PR TITLE
web: 详情面板补充「删除并删除文件」入口 (#350)

### DIFF
--- a/web/src/components/tasks/DetailPanel.tsx
+++ b/web/src/components/tasks/DetailPanel.tsx
@@ -3,7 +3,7 @@
 
 import { useEffect, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { Ban, Download, ListOrdered, Pencil, Trash2, X, Zap } from 'lucide-react'
+import { Ban, Download, FileX, ListOrdered, Pencil, Trash2, X, Zap } from 'lucide-react'
 import { api, taskFileUrl } from '../../lib/api'
 import { CopyButton } from '../CopyButton'
 import { cn } from '../../lib/cn'
@@ -252,6 +252,17 @@ function GeneralTab({ t, queues, groups }: { t: ViewTask; queues: QueueDto[]; gr
         >
           <Trash2 size={15} />
           {tr('task.delete')}
+        </button>
+        <button
+          type="button"
+          className="btn danger sm"
+          onClick={async () => {
+            if (await confirmDialog({ title: tr('task.deleteTitle'), message: tr('task.deleteWithFilesMsg'), danger: true }))
+              deleteMut.mutate(true)
+          }}
+        >
+          <FileX size={15} />
+          {tr('task.deleteWithFiles')}
         </button>
       </div>
     </>


### PR DESCRIPTION
## 问题
右侧任务详情面板底部只有「删除」按钮（仅删记录），列表右键菜单已有「删除并删除文件」，详情面板缺该入口。

## 改动
- `web/src/components/tasks/DetailPanel.tsx`：`GeneralTab` 底部操作区新增第二个危险色按钮，点击调用 `deleteMut.mutate(true)`（已有 mutation 支持 deleteFiles 参数）。
- 复用列表侧已有 i18n 键 `task.deleteWithFiles` / `task.deleteTitle` / `task.deleteWithFilesMsg`（无需新增翻译）。
- 图标沿用 ManageBar 批量删文件按钮的 `FileX`，与「删除」按钮保持一致的 `btn danger sm` 样式类名。

## 验证
`cd web && bunx tsc --noEmit -p .` 通过，无报错。

Closes #350