### PR TITLE
BT 任务速度列调整上传/下载显示顺序 (#483)

### DIFF
--- a/lib/src/widgets/task_columns.dart
+++ b/lib/src/widgets/task_columns.dart
@@ -344,18 +344,18 @@ final Map<TaskColumnId, TaskColumnDef> kTaskColumns = {
           mainAxisAlignment: MainAxisAlignment.center,
           crossAxisAlignment: CrossAxisAlignment.end,
           children: [
-            if (hasDown)
+            if (hasUp)
               Text(
-                '↓ ${DownloadTask.formatBytes(down)}/s',
+                '↑ ${DownloadTask.formatBytes(up)}/s',
                 style: TextStyle(
                   fontSize: 11,
                   color: AppColors.green,
                   fontFeatures: const [FontFeature.tabularFigures()],
                 ),
               ),
-            if (hasUp)
+            if (hasDown)
               Text(
-                '↑ ${DownloadTask.formatBytes(up)}/s',
+                '↓ ${DownloadTask.formatBytes(down)}/s',
                 style: TextStyle(
                   fontSize: 11,
                   color: AppColors.green,


### PR DESCRIPTION
调整 lib/src/widgets/task_columns.dart 中 BT 任务速度列 Column 内 ↑/↓ 的显示顺序：上传（↑）在上，下载（↓）在下，更符合用户直觉。

已 grep 确认 detail_panel.dart、task_group_card.dart、task_list.dart、web/src 中相关速度显示均为单行（只显示 ↓ 或 ↑ 之一），无其它同形态上下堆叠场景需要同步调整。

验证：`dart analyze lib/src/widgets/task_columns.dart` 无 error。

Closes #483