### PR TITLE
fix(engine): 兼容 Content-Encoding: utf-8/utf8 字符集误写 (#413)

### DIFF
--- a/native/engine/src/downloader.rs
+++ b/native/engine/src/downloader.rs
@@ -663,7 +663,13 @@ pub fn unsupported_content_encoding(headers: &reqwest::header::HeaderMap) -> Opt
             // 表达"未压缩"（等价于省略该头或写 identity）。按未知编码处理会把
             // 明确声明"无压缩"的响应误判为不可解码的压缩层，导致下载被永久拒绝
             // （BUG-HTTP-NONE-ENCODING-FALSE-POSITIVE）。
-            "identity" | "none" | "" => {}
+            //
+            // "utf-8"/"utf8" 同理不是压缩编码，而是字符集 token——个别 CDN
+            // （如 OPPO/一加 OTA 域名 gauss-compotaauto-c-cn.allawnfs.com）把
+            // 字符编码错填进 Content-Encoding 头，响应体实际未压缩。按未知
+            // 编码拒绝会把这类误写永久挡在下载之外（#413），故与 "none" 一样
+            // 按 no-op 放行。
+            "identity" | "none" | "" | "utf-8" | "utf8" => {}
             "gzip" | "x-gzip" | "br" | "brotli" | "deflate" | "zstd" => layers.push(lower),
             other => {
                 has_unknown = true;
@@ -5417,6 +5423,19 @@ mod tests {
             reqwest::header::HeaderValue::from_static("none"),
         );
         assert!(super::unsupported_content_encoding(&headers).is_none());
+    }
+
+    #[test]
+    fn content_encoding_utf8_charset_is_noop() {
+        // #413: OPPO/一加 OTA CDN 把字符集误写进 Content-Encoding，响应体实际
+        // 未压缩——须与 "none" 同样按 no-op 放行，而非当作未知压缩层拒绝下载。
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            reqwest::header::CONTENT_ENCODING,
+            reqwest::header::HeaderValue::from_static("UTF-8"),
+        );
+        assert!(super::unsupported_content_encoding(&headers).is_none());
+        assert!(super::detect_content_encoding(&headers).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## 问题
OPPO/一加 OTA CDN（`gauss-compotaauto-c-cn.allawnfs.com`）返回 `Content-Encoding: UTF-8`（实际是把字符集误写进了内容编码头），响应体实际未压缩。`unsupported_content_encoding()` 之前把它当作未知压缩层，永久拒绝下载。

## 改动
- `native/engine/src/downloader.rs`：`unsupported_content_encoding()` 的 `match` 中把 `"utf-8" | "utf8"`（大小写不敏感，`lower` 已小写）并入现有 `"identity" | "none" | ""` no-op 分支，并补充注释说明来源（#413）。
- 检查了 `~1327` 处的 `Accept-Ranges` 判定（`v != "none"`）：该处比较的是 `Accept-Ranges` 头而非 `Content-Encoding`，与本 issue 无关，未改动。
- `detect_content_encoding()` 对未知 token（含 utf-8/utf8）本就落入 `_ => continue`，无需改动。
- 新增回归测试 `content_encoding_utf8_charset_is_noop`（覆盖大写 `UTF-8` 写法），断言 `unsupported_content_encoding` 与 `detect_content_encoding` 均返回 `None`。

## 验证
- `CARGO_TARGET_DIR=.../target cargo check -p fluxdown_engine --lib` — 通过
- `cargo nextest` 未安装于本机，改用 `CARGO_TARGET_DIR=.../target cargo test -p fluxdown_engine --lib content_encoding` — 15/15 通过（含新增测试）

Closes #413