### PR TITLE
新建下载对话框打开后自动聚焦 URL 输入框 (#439)

### DIFF
--- a/lib/src/widgets/new_download_dialog.dart
+++ b/lib/src/widgets/new_download_dialog.dart
@@ -1631,6 +1631,7 @@ class _NewDownloadDialogContentState extends State<_NewDownloadDialogContent> {
                           child: TextField(
                             controller: _urlController,
                             focusNode: _urlFocusNode,
+                            autofocus: true,
                             maxLines: null,
                             expands: true,
                             textAlignVertical: TextAlignVertical.top,


### PR DESCRIPTION
## 问题
点击「新建下载」打开对话框后，光标不在下载链接/URL 输入框，需要用户手动点击一次才能输入或粘贴。

## 改动
- `lib/src/widgets/new_download_dialog.dart`：给 URL 输入的 `TextField`（已绑定独立 `_urlFocusNode`）加上 `autofocus: true`，打开对话框即聚焦到该输入框。
- 对话框 `initState` 里的剪切板预填（`_pasteUrlFromClipboard`）发生在首帧渲染之前，autofocus 生效时文本已就位，光标停在已填内容上，无需额外条件判断。
- 用法与仓库内 `category_edit_dialog.dart`、`sidebar.dart`、`task_list_item.dart` 等既有 `autofocus: true` 惯例一致。

## 验证
```
rinf gen
dart analyze lib/src/widgets/new_download_dialog.dart
# Analyzing new_download_dialog.dart...
# No issues found!
```

Closes #439