### PR TITLE
Web 顶栏新增浅色/深色主题一键切换按钮 (#352)

### DIFF
--- a/web/src/components/tasks/TopBar.tsx
+++ b/web/src/components/tasks/TopBar.tsx
@@ -4,7 +4,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
-import { Gauge, ListChecks, Menu, Pause, Play, Plus, Search, Settings } from 'lucide-react'
+import { Gauge, ListChecks, Menu, Moon, Pause, Play, Plus, Search, Settings, Sun } from 'lucide-react'
 import { api } from '../../lib/api'
 import { cn } from '../../lib/cn'
 import { openNewDownload } from '../../lib/dialogs'
@@ -12,6 +12,7 @@ import { fmtSpeed } from '../../lib/format'
 import { useI18n } from '../../lib/i18n'
 import { GROUP_BY_CYCLE, SORT_KEY_CYCLE, SORT_KEY_DEFAULT_DIR, updateViewPrefs } from '../../lib/view-prefs'
 import { useConfigQuery } from '../../lib/config'
+import { useTheme } from '../../lib/theme'
 import { useTasksUi } from './context'
 import { useViewTasks } from './useViewTasks'
 import { ViewOptionsPanelButton } from './ViewOptionsPanel'
@@ -19,6 +20,7 @@ import { ViewOptionsPanelButton } from './ViewOptionsPanel'
 export function TopBar() {
   const { t } = useI18n()
   const navigate = useNavigate()
+  const { mode, setMode } = useTheme()
   const { search, setSearch, manageMode, setManageMode, setSidebarOpen, statusTab } = useTasksUi()
   const tasks = useViewTasks()
   const qc = useQueryClient()
@@ -75,6 +77,7 @@ export function TopBar() {
   }, [statusTab])
 
   const hasActive = tasks.some((t) => t.status === 0 || t.status === 1 || t.status === 5)
+  const isDark = mode === 'dark' || (mode === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
   const invalidate = () => qc.invalidateQueries({ queryKey: ['tasks'] })
   const pauseAll = useMutation({ mutationFn: api.pauseAll, onSuccess: invalidate })
   const continueAll = useMutation({ mutationFn: api.continueAll, onSuccess: invalidate })
@@ -118,6 +121,14 @@ export function TopBar() {
         <button type="button" className="btn primary" onClick={openNewDownload}>
           <Plus size={15} />
           <span className="btn-label">{t('topbar.newDownload')}</span>
+        </button>
+        <button
+          type="button"
+          className="icon-btn"
+          title={t('topbar.toggleTheme')}
+          onClick={() => setMode(isDark ? 'light' : 'dark')}
+        >
+          {isDark ? <Sun size={17} /> : <Moon size={17} />}
         </button>
         <button type="button" className="icon-btn" title={t('common.settings')} onClick={() => navigate({ to: '/settings' })}>
           <Settings size={17} />

--- a/web/src/lib/locales/en.json
+++ b/web/src/lib/locales/en.json
@@ -273,6 +273,7 @@
   "topbar.speedLimitOn": "Download limit: {speed}",
   "topbar.speedLimitOff": "Download limit: off",
   "topbar.goSettings": "{label} (adjust in Settings)",
+  "topbar.toggleTheme": "Toggle light/dark theme",
   "tabs.all": "All",
   "tabs.downloading": "Downloading",
   "tabs.completed": "Completed",

--- a/web/src/lib/locales/zh.json
+++ b/web/src/lib/locales/zh.json
@@ -273,6 +273,7 @@
   "topbar.speedLimitOn": "下载限速：{speed}",
   "topbar.speedLimitOff": "下载限速：未开启",
   "topbar.goSettings": "{label}（前往设置调整）",
+  "topbar.toggleTheme": "切换浅色 / 深色主题",
   "tabs.all": "全部",
   "tabs.downloading": "下载中",
   "tabs.completed": "已完成",


### PR DESCRIPTION
## 改动
- `web/src/components/tasks/TopBar.tsx`：在设置图标按钮左侧新增主题切换图标按钮，复用现有 `icon-btn` 样式；点击时读取 `useTheme()` 的 `mode`，system 模式下按 `prefers-color-scheme` 判断当前实际生效主题取反，直接调用 `setMode('light'|'dark')` 持久化。图标使用 lucide `Sun`/`Moon`，随当前是否为深色态切换。
- `web/src/lib/locales/{en,zh}.json`：新增 `topbar.toggleTheme` 文案键，供按钮 tooltip/aria title 使用。

## 验证
`cd web && bunx tsc --noEmit -p .` 通过（无输出）。

Closes #352