### PR TITLE
智能排序：非活跃任务按创建时间降序，最新在上 (#429)

### DIFF
--- a/lib/src/models/download_controller.dart
+++ b/lib/src/models/download_controller.dart
@@ -2623,9 +2623,11 @@ bucketFunctionTable(List<DownloadQueue> queues) => {
 };
 
 /// 「智能」排序比较器：状态优先级（下载中0 < 准备/恢复中1 < 排队2 <
-/// 暂停3 < 失败4 < 完成5）→ 排队内按队列位置 → 其余按创建时间升序，
-/// 固定升序稳定、忽略 [SortDir]（design-proto-spec §3 `smart` 语义，对齐
-/// 现状 `_compareActiveTasks` 并推广到全部状态，保证默认视图零感知）。
+/// 暂停3 < 失败4 < 完成5）→ 排队内按队列位置 → 活跃层（下载中/准备/恢复中）
+/// 按创建时间升序、顺序稳定不抖动（对齐现状 `_compareActiveTasks`）；
+/// 其余非活跃层（排队外的暂停/失败/完成/取消）按创建时间降序，最新任务
+/// 靠前，符合用户预期（#429）。固定忽略 [SortDir]（design-proto-spec §3
+/// `smart` 语义）。
 int compareEntitiesSmart(ListEntity a, ListEntity b) {
   int tier(TaskStatus s) => switch (s) {
     TaskStatus.downloading => 0,
@@ -2637,14 +2639,20 @@ int compareEntitiesSmart(ListEntity a, ListEntity b) {
     TaskStatus.completed => 5,
     TaskStatus.canceled => 6,
   };
-  final diff = tier(a.statusBucket) - tier(b.statusBucket);
+  final aTier = tier(a.statusBucket);
+  final diff = aTier - tier(b.statusBucket);
   if (diff != 0) return diff;
   if (a.statusBucket == TaskStatus.pending &&
       a is TaskEntity &&
       b is TaskEntity) {
     return a.task.queuePosition.compareTo(b.task.queuePosition);
   }
-  return a.createdAt.compareTo(b.createdAt);
+  if (aTier <= 1) {
+    // 活跃任务：按创建时间升序，顺序稳定不抖动。
+    return a.createdAt.compareTo(b.createdAt);
+  }
+  // 非活跃任务：按创建时间降序，最新在前。
+  return b.createdAt.compareTo(a.createdAt);
 }
 
 /// 6 键排序比较器表（`smart` 忽略 [dir]；其余按 [dir] 升/降序，

--- a/test/list_sections_test.dart
+++ b/test/list_sections_test.dart
@@ -184,7 +184,7 @@ void main() {
   group('compareEntities (6 keys x direction)', () {
     final base = DateTime(2026, 1, 1);
 
-    test('smart: status tier then createdAt ascending, direction ignored', () {
+    test('smart: active tasks createdAt ascending, non-active descending, direction ignored', () {
       final active = TaskEntity(_task(id: 'a', status: TaskStatus.downloading, createdAt: base));
       final pending = TaskEntity(_task(id: 'b', status: TaskStatus.pending, createdAt: base));
       expect(compareEntities(ViewSortKey.smart, SortDir.asc, active, pending), lessThan(0));
@@ -196,7 +196,9 @@ void main() {
       final newer = TaskEntity(
         _task(id: 'd', status: TaskStatus.completed, createdAt: base.add(const Duration(days: 1))),
       );
-      expect(compareEntities(ViewSortKey.smart, SortDir.desc, older, newer), lessThan(0));
+      // 非活跃（已完成）任务按创建时间降序：更新的排在前面。
+      expect(compareEntities(ViewSortKey.smart, SortDir.desc, older, newer), greaterThan(0));
+      expect(compareEntities(ViewSortKey.smart, SortDir.asc, older, newer), greaterThan(0));
     });
 
     test('smart: pending entities tie-break by queue position', () {


### PR DESCRIPTION
## 问题
智能排序 `compareEntitiesSmart` 中，同一状态分层内固定按 `createdAt` 升序排列，导致同一分组（如「今天」）内最新添加/完成的任务出现在底部，与用户预期的「最新在上」相悖。

## 改动
- `lib/src/models/download_controller.dart`：`compareEntitiesSmart` 中，非活跃层（暂停/失败/完成/取消）改为按 `createdAt` **降序**排列，最新任务排在分组顶部；活跃层（下载中/准备中/恢复中）保持原有的 `createdAt` 升序，以维持顺序稳定不抖动（沿用 `_compareActiveTasks` 的既有理由）。
- `test/list_sections_test.dart`：更新对应的智能排序期望测试。

## 验证
- `dart analyze lib/src/models/download_controller.dart test/list_sections_test.dart`：No issues found!
- `flutter test test/list_sections_test.dart`：24/24 通过。

Closes #429