### PR TITLE
任务详情：日志文字可选中复制，错误栏改红色醒目样式 (#537)

### DIFF
--- a/lib/src/widgets/detail_panel.dart
+++ b/lib/src/widgets/detail_panel.dart
@@ -1472,33 +1472,46 @@ class _DetailPanelState extends State<DetailPanel> {
   Widget _buildErrorRow(AppColors c, String message) {
     return Padding(
       padding: const EdgeInsets.only(bottom: 10),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          SizedBox(
-            width: 60,
-            child: Text(
-              currentS.infoError,
-              style: TextStyle(fontSize: 11, color: c.textMuted),
-            ),
-          ),
-          Expanded(
-            child: Text(
-              message,
-              style: TextStyle(
-                fontSize: 11,
-                color: c.textSecondary,
-                fontFeatures: const [FontFeature.tabularFigures()],
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+        decoration: BoxDecoration(
+          color: AppColors.red.withValues(alpha: 0.06),
+          borderRadius: BorderRadius.circular(6),
+          border: Border.all(color: AppColors.red.withValues(alpha: 0.25)),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SizedBox(
+              width: 60,
+              child: Text(
+                currentS.infoError,
+                style: const TextStyle(
+                  fontSize: 11,
+                  color: AppColors.red,
+                  fontWeight: FontWeight.w500,
+                ),
               ),
             ),
-          ),
-          const SizedBox(width: 4),
-          _CopyValueButton(
-            value: message,
-            color: c.textMuted,
-            toastText: currentS.errorCopied,
-          ),
-        ],
+            Expanded(
+              child: Text(
+                message,
+                style: const TextStyle(
+                  fontSize: 11,
+                  color: AppColors.red,
+                  fontFeatures: [FontFeature.tabularFigures()],
+                ),
+              ),
+            ),
+            const SizedBox(width: 4),
+            _CopyValueButton(
+              value: message,
+              color: AppColors.red,
+              toastText: currentS.errorCopied,
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -1745,12 +1758,17 @@ class _DetailPanelState extends State<DetailPanel> {
     String text, {
     bool isError = false,
   }) {
-    final textWidget = Text(
-      text,
-      style: TextStyle(
-        fontSize: 11,
-        fontFamily: 'monospace',
-        color: isError ? AppColors.red : c.textSecondary,
+    final m = AppMetrics.of(context);
+    final textWidget = DefaultSelectionStyle(
+      selectionColor: m.soft(c.accent),
+      cursorColor: c.accent,
+      child: SelectableText(
+        text,
+        style: TextStyle(
+          fontSize: 11,
+          fontFamily: 'monospace',
+          color: isError ? AppColors.red : c.textSecondary,
+        ),
       ),
     );
     if (time == null) {


### PR DESCRIPTION
## 改动
- `_buildLogRow`（日志页）消息文本改用 `SelectableText`，包一层 `DefaultSelectionStyle` 使选区/光标色跟随主题 accent（与 `webhook_delivery_panel.dart` 里 `SelectableMonoText` 的实现一致），支持拖选复制日志/错误原文。
- `_buildErrorRow`（常规页错误栏）标签、正文、复制按钮颜色统一改为 `AppColors.red`，并给整行加淡红色背景 + 边框（参考 `_buildPluginActivityCard` 的 accent 淡色容器写法），更醒目。

## 验证
- `dart analyze lib/src/widgets/detail_panel.dart`：改动前后均为同样的 3 个预置错误（均因该 worktree 缺少 build_runner 生成的 `lib/src/bindings/bindings.dart` 等生成文件所致，与本次改动无关），未引入新 error。

Closes #537