### PR TITLE
fix(i18n): 输入框右键菜单跟随应用语言 (#515)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -34,6 +34,7 @@ import 'src/services/notification_service.dart';
 import 'src/services/power_service.dart';
 import 'src/services/tray_service.dart';
 import 'src/i18n/locale_provider.dart';
+import 'src/i18n/framework_localizations.dart';
 import 'src/services/update_service.dart';
 import 'src/theme/app_theme.dart';
 import 'src/theme/flux_theme_tokens.dart';
@@ -108,6 +109,10 @@ Future<void> main(List<String> args) async {
   ]);
   localeNotifier = LocaleNotifier();
   await _runStartupStep('locale init', () => localeNotifier.init());
+  await _runStartupStep(
+    'shad l10n warmup',
+    () => AppShadLocalizationsDelegate.warmUp(frameworkLocale(currentLocale)),
+  );
 
   // 注：已移除 desktop_multi_window 子窗口入口。
   // 下载完成通知现在通过主窗口内 OverlayEntry 实现，
@@ -1028,6 +1033,7 @@ class _FluxDownAppState extends State<FluxDownApp>
     // - materialTheme() 每帧重建 ThemeData + applyGoogleFontToTextTheme
     final tokens = _resolveTokens(context);
     final theme = buildThemeFromTokens(tokens);
+    final fl = frameworkLocale(_localeNotifier.s.locale);
     WidgetsBinding.instance.addPostFrameCallback(
       (_) => _syncMacOsWindowBackground(tokens),
     );
@@ -1051,6 +1057,9 @@ class _FluxDownAppState extends State<FluxDownApp>
                       navigatorKey: _navigatorKey,
                       color: theme.colorScheme.primary,
                       debugShowCheckedModeBanner: false,
+                      locale: fl,
+                      supportedLocales: [fl],
+                      localizationsDelegates: frameworkLocalizationDelegates,
                       home: HomePage(settingsProvider: _settingsForExternal),
                       builder: (context, child) {
                         final scale = themeProvider.uiScale;

--- a/lib/src/i18n/framework_localizations.dart
+++ b/lib/src/i18n/framework_localizations.dart
@@ -1,0 +1,107 @@
+// 应用根是裸 WidgetsApp（main.dart / mobile_app.dart / popup_app.dart 均未挂
+// MaterialApp / ShadApp），但两套输入控件都要求树上有对应的
+// LocalizationsDelegate 才能取到本地化文案：
+// - Material `TextField` 经 MaterialLocalizations 取「复制/粘贴/全选」等，
+//   没有对应 delegate 会直接抛异常；
+// - shadcn 的 `ShadInput` 右键菜单经 `ShadLocalizations.of(context)` 取同类
+//   文案，没有对应 delegate 时不抛异常，而是悄悄回退
+//   `ShadLocalizationsData()`（英文默认值）——此前应用语言切到中文，
+//   ShadInput 菜单仍固定英文正是这个原因（issue #515）。
+//
+// 本文件提供三个 WidgetsApp 根统一挂载所需的东西：
+// - [frameworkLocale]：把 i18n locale 代码解析为 Material/Widgets 本地化
+//   实际支持的 [Locale]；
+// - [AppShadLocalizationsDelegate] + [AppShadLocalizationsDelegate.warmUp]：
+//   带同步缓存的 shadcn 本地化 delegate，配合预热避免异步加载期间的空白帧；
+// - [frameworkLocalizationDelegates]：三个根共用的 delegate 列表。
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+/// 把 i18n locale 代码（如 `'en'`、`'zh'`、`'zh-hant'`、`'zh-tw'`）解析成
+/// Material/Widgets 本地化实际支持的 [Locale]；解析结果不受支持时回退英文，
+/// 避免 `MaterialLocalizations.of(context)` 因未知语言抛出异常。
+Locale frameworkLocale(String code) {
+  final parts = code
+      .split(RegExp(r'[-_]'))
+      .where((p) => p.isNotEmpty)
+      .toList();
+  final Locale locale;
+  if (parts.isEmpty) {
+    // 空串/纯分隔符：Locale 构造器断言 languageCode 非空，直接回退英文。
+    return const Locale('en');
+  } else if (parts.length == 1) {
+    locale = Locale(parts.first);
+  } else {
+    final language = parts[0];
+    final sub = parts[1];
+    locale = sub.length == 4
+        // 4 字母子标签 → script（如 zh-Hant、zh-Hans），首字母大写。
+        ? Locale.fromSubtags(
+            languageCode: language,
+            scriptCode: sub[0].toUpperCase() + sub.substring(1).toLowerCase(),
+          )
+        // 2-3 字母子标签 → country（如 zh-TW、en-US），全大写。
+        : Locale.fromSubtags(
+            languageCode: language,
+            countryCode: sub.toUpperCase(),
+          );
+  }
+  return GlobalMaterialLocalizations.delegate.isSupported(locale)
+      ? locale
+      : const Locale('en');
+}
+
+/// 包一层同步缓存的 [GlobalShadLocalizations]。
+///
+/// `GlobalShadLocalizations.load()` 对英文走同步路径，对其余语言经
+/// deferred import 异步加载（`strings.g.dart` 里 `await l_zh.loadLibrary()`
+/// 之类）。已挂载的 `Localizations` 在异步刷新期间会保留旧资源渲染、不会
+/// 空白（见 flutter 源码 `_LocalizationsState.didUpdateWidget`/`load`），
+/// 但**全新挂载**的 `Localizations`（如弹窗小窗每次新载荷都用
+/// `ValueKey(_epoch)` 重建整棵 `WidgetsApp`）在资源到达前会渲染
+/// `SizedBox.shrink()`，也就是一帧空白。
+///
+/// 命中缓存的语言直接同步返回，从根源避免这一帧空白；[warmUp] 用于在
+/// 语言切换 / 弹窗投递新载荷触发 `setState` 之前，把目标语言预热进缓存。
+class AppShadLocalizationsDelegate
+    extends LocalizationsDelegate<ShadLocalizationsData> {
+  const AppShadLocalizationsDelegate._();
+
+  /// 单例。
+  static const delegate = AppShadLocalizationsDelegate._();
+
+  static final _cache = <String, ShadLocalizationsData>{};
+
+  @override
+  bool isSupported(Locale locale) => true;
+
+  @override
+  Future<ShadLocalizationsData> load(Locale locale) {
+    final key = locale.toLanguageTag();
+    final cached = _cache[key];
+    if (cached != null) {
+      return SynchronousFuture<ShadLocalizationsData>(cached);
+    }
+    return GlobalShadLocalizations.delegate.load(locale).then((data) {
+      _cache[key] = data;
+      return data;
+    });
+  }
+
+  @override
+  bool shouldReload(AppShadLocalizationsDelegate old) => false;
+
+  /// 预热 [locale] 的 shadcn 本地化资源；返回后 [load] 同一 locale
+  /// 会同步命中缓存，不再触发异步加载。
+  static Future<void> warmUp(Locale locale) => delegate.load(locale);
+}
+
+/// 三个 WidgetsApp 根（main / mobile / popup）统一使用的本地化 delegate 列表。
+const frameworkLocalizationDelegates = <LocalizationsDelegate<dynamic>>[
+  AppShadLocalizationsDelegate.delegate,
+  GlobalWidgetsLocalizations.delegate,
+  GlobalMaterialLocalizations.delegate,
+];

--- a/lib/src/mobile/mobile_app.dart
+++ b/lib/src/mobile/mobile_app.dart
@@ -4,6 +4,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 
+import '../i18n/framework_localizations.dart';
 import '../i18n/locale_provider.dart';
 import '../services/bt_file_selection_service.dart';
 import '../services/hls_quality_service.dart';
@@ -68,6 +69,7 @@ class _FluxDownMobileAppState extends State<FluxDownMobileApp> {
   Widget build(BuildContext context) {
     final FluxThemeTokens tokens = widget.themeProvider.activeTokens(context);
     final theme = buildThemeFromTokens(tokens);
+    final fl = frameworkLocale(widget.localeNotifier.s.locale);
 
     // Android 系统栏图标按当前主题反色；亮色主题用深色图标，暗色主题反之。
     final iconBrightness = tokens.appearance == Brightness.dark
@@ -105,6 +107,9 @@ class _FluxDownMobileAppState extends State<FluxDownMobileApp> {
                       navigatorKey: _navigatorKey,
                       color: theme.colorScheme.primary,
                       debugShowCheckedModeBanner: false,
+                      locale: fl,
+                      supportedLocales: [fl],
+                      localizationsDelegates: frameworkLocalizationDelegates,
                       home: WithForegroundTask(
                         child: MobileShell(
                           themeProvider: widget.themeProvider,

--- a/lib/src/pages/settings_page.dart
+++ b/lib/src/pages/settings_page.dart
@@ -8222,55 +8222,48 @@ class _BtTrackerEditorState extends State<_BtTrackerEditor> {
           const SizedBox(height: 8),
           SizedBox(
             height: 240,
-            child: Localizations(
-              locale: const Locale('en'),
-              delegates: const [
-                DefaultWidgetsLocalizations.delegate,
-                DefaultMaterialLocalizations.delegate,
-              ],
-              child: Material(
-                type: MaterialType.transparency,
-                child: TextSelectionTheme(
-                  data: TextSelectionThemeData(
-                    selectionColor: m.textSelection(c.accent),
-                    cursorColor: c.accent,
-                    selectionHandleColor: c.accent,
+            child: Material(
+              type: MaterialType.transparency,
+              child: TextSelectionTheme(
+                data: TextSelectionThemeData(
+                  selectionColor: m.textSelection(c.accent),
+                  cursorColor: c.accent,
+                  selectionHandleColor: c.accent,
+                ),
+                child: TextField(
+                  controller: _controller,
+                  maxLines: null,
+                  expands: true,
+                  textAlignVertical: TextAlignVertical.top,
+                  cursorColor: c.accent,
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: c.textPrimary,
+                    fontFamily: 'monospace',
+                    height: 1.5,
                   ),
-                  child: TextField(
-                    controller: _controller,
-                    maxLines: null,
-                    expands: true,
-                    textAlignVertical: TextAlignVertical.top,
-                    cursorColor: c.accent,
-                    style: TextStyle(
-                      fontSize: 12,
-                      color: c.textPrimary,
-                      fontFamily: 'monospace',
-                      height: 1.5,
+                  decoration: InputDecoration(
+                    hintText: s.btTrackerPlaceholder,
+                    hintStyle: TextStyle(fontSize: 12, color: c.textMuted),
+                    hintMaxLines: 5,
+                    contentPadding: const EdgeInsets.all(10),
+                    filled: true,
+                    fillColor: c.inputBg,
+                    hoverColor: Colors.transparent,
+                    border: OutlineInputBorder(
+                      borderRadius: m.brInput,
+                      borderSide: BorderSide(color: c.inputBorder),
                     ),
-                    decoration: InputDecoration(
-                      hintText: s.btTrackerPlaceholder,
-                      hintStyle: TextStyle(fontSize: 12, color: c.textMuted),
-                      hintMaxLines: 5,
-                      contentPadding: const EdgeInsets.all(10),
-                      filled: true,
-                      fillColor: c.inputBg,
-                      hoverColor: Colors.transparent,
-                      border: OutlineInputBorder(
-                        borderRadius: m.brInput,
-                        borderSide: BorderSide(color: c.inputBorder),
-                      ),
-                      enabledBorder: OutlineInputBorder(
-                        borderRadius: m.brInput,
-                        borderSide: BorderSide(color: c.inputBorder),
-                      ),
-                      focusedBorder: OutlineInputBorder(
-                        borderRadius: m.brInput,
-                        borderSide: BorderSide(color: c.inputFocusBorder),
-                      ),
+                    enabledBorder: OutlineInputBorder(
+                      borderRadius: m.brInput,
+                      borderSide: BorderSide(color: c.inputBorder),
                     ),
-                    onChanged: (_) => setState(() {}),
+                    focusedBorder: OutlineInputBorder(
+                      borderRadius: m.brInput,
+                      borderSide: BorderSide(color: c.inputFocusBorder),
+                    ),
                   ),
+                  onChanged: (_) => setState(() {}),
                 ),
               ),
             ),
@@ -8509,52 +8502,45 @@ class _BtTrackerSubEditorState extends State<_BtTrackerSubEditor> {
             const SizedBox(height: 8),
             SizedBox(
               height: 100,
-              child: Localizations(
-                locale: const Locale('en'),
-                delegates: const [
-                  DefaultWidgetsLocalizations.delegate,
-                  DefaultMaterialLocalizations.delegate,
-                ],
-                child: Material(
-                  type: MaterialType.transparency,
-                  child: TextSelectionTheme(
-                    data: TextSelectionThemeData(
-                      selectionColor: m.textSelection(c.accent),
-                      cursorColor: c.accent,
-                      selectionHandleColor: c.accent,
+              child: Material(
+                type: MaterialType.transparency,
+                child: TextSelectionTheme(
+                  data: TextSelectionThemeData(
+                    selectionColor: m.textSelection(c.accent),
+                    cursorColor: c.accent,
+                    selectionHandleColor: c.accent,
+                  ),
+                  child: TextField(
+                    controller: _controller,
+                    maxLines: null,
+                    expands: true,
+                    textAlignVertical: TextAlignVertical.top,
+                    cursorColor: c.accent,
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: c.textPrimary,
+                      fontFamily: 'monospace',
+                      height: 1.5,
                     ),
-                    child: TextField(
-                      controller: _controller,
-                      maxLines: null,
-                      expands: true,
-                      textAlignVertical: TextAlignVertical.top,
-                      cursorColor: c.accent,
-                      style: TextStyle(
-                        fontSize: 12,
-                        color: c.textPrimary,
-                        fontFamily: 'monospace',
-                        height: 1.5,
+                    decoration: InputDecoration(
+                      hintText: s.btTrackerSubPlaceholder,
+                      hintStyle: TextStyle(fontSize: 12, color: c.textMuted),
+                      hintMaxLines: 3,
+                      contentPadding: const EdgeInsets.all(10),
+                      filled: true,
+                      fillColor: c.inputBg,
+                      hoverColor: Colors.transparent,
+                      border: OutlineInputBorder(
+                        borderRadius: m.brInput,
+                        borderSide: BorderSide(color: c.inputBorder),
                       ),
-                      decoration: InputDecoration(
-                        hintText: s.btTrackerSubPlaceholder,
-                        hintStyle: TextStyle(fontSize: 12, color: c.textMuted),
-                        hintMaxLines: 3,
-                        contentPadding: const EdgeInsets.all(10),
-                        filled: true,
-                        fillColor: c.inputBg,
-                        hoverColor: Colors.transparent,
-                        border: OutlineInputBorder(
-                          borderRadius: m.brInput,
-                          borderSide: BorderSide(color: c.inputBorder),
-                        ),
-                        enabledBorder: OutlineInputBorder(
-                          borderRadius: m.brInput,
-                          borderSide: BorderSide(color: c.inputBorder),
-                        ),
-                        focusedBorder: OutlineInputBorder(
-                          borderRadius: m.brInput,
-                          borderSide: BorderSide(color: c.inputFocusBorder),
-                        ),
+                      enabledBorder: OutlineInputBorder(
+                        borderRadius: m.brInput,
+                        borderSide: BorderSide(color: c.inputBorder),
+                      ),
+                      focusedBorder: OutlineInputBorder(
+                        borderRadius: m.brInput,
+                        borderSide: BorderSide(color: c.inputFocusBorder),
                       ),
                     ),
                   ),
@@ -8775,55 +8761,48 @@ class _Ed2kServerEditorState extends State<_Ed2kServerEditor> {
           const SizedBox(height: 8),
           SizedBox(
             height: 200,
-            child: Localizations(
-              locale: const Locale('en'),
-              delegates: const [
-                DefaultWidgetsLocalizations.delegate,
-                DefaultMaterialLocalizations.delegate,
-              ],
-              child: Material(
-                type: MaterialType.transparency,
-                child: TextSelectionTheme(
-                  data: TextSelectionThemeData(
-                    selectionColor: m.textSelection(c.accent),
-                    cursorColor: c.accent,
-                    selectionHandleColor: c.accent,
+            child: Material(
+              type: MaterialType.transparency,
+              child: TextSelectionTheme(
+                data: TextSelectionThemeData(
+                  selectionColor: m.textSelection(c.accent),
+                  cursorColor: c.accent,
+                  selectionHandleColor: c.accent,
+                ),
+                child: TextField(
+                  controller: _controller,
+                  maxLines: null,
+                  expands: true,
+                  textAlignVertical: TextAlignVertical.top,
+                  cursorColor: c.accent,
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: c.textPrimary,
+                    fontFamily: 'monospace',
+                    height: 1.5,
                   ),
-                  child: TextField(
-                    controller: _controller,
-                    maxLines: null,
-                    expands: true,
-                    textAlignVertical: TextAlignVertical.top,
-                    cursorColor: c.accent,
-                    style: TextStyle(
-                      fontSize: 12,
-                      color: c.textPrimary,
-                      fontFamily: 'monospace',
-                      height: 1.5,
+                  decoration: InputDecoration(
+                    hintText: s.ed2kServerPlaceholder,
+                    hintStyle: TextStyle(fontSize: 12, color: c.textMuted),
+                    hintMaxLines: 3,
+                    contentPadding: const EdgeInsets.all(10),
+                    filled: true,
+                    fillColor: c.inputBg,
+                    hoverColor: Colors.transparent,
+                    border: OutlineInputBorder(
+                      borderRadius: m.brInput,
+                      borderSide: BorderSide(color: c.inputBorder),
                     ),
-                    decoration: InputDecoration(
-                      hintText: s.ed2kServerPlaceholder,
-                      hintStyle: TextStyle(fontSize: 12, color: c.textMuted),
-                      hintMaxLines: 3,
-                      contentPadding: const EdgeInsets.all(10),
-                      filled: true,
-                      fillColor: c.inputBg,
-                      hoverColor: Colors.transparent,
-                      border: OutlineInputBorder(
-                        borderRadius: m.brInput,
-                        borderSide: BorderSide(color: c.inputBorder),
-                      ),
-                      enabledBorder: OutlineInputBorder(
-                        borderRadius: m.brInput,
-                        borderSide: BorderSide(color: c.inputBorder),
-                      ),
-                      focusedBorder: OutlineInputBorder(
-                        borderRadius: m.brInput,
-                        borderSide: BorderSide(color: c.inputFocusBorder),
-                      ),
+                    enabledBorder: OutlineInputBorder(
+                      borderRadius: m.brInput,
+                      borderSide: BorderSide(color: c.inputBorder),
                     ),
-                    onChanged: (_) => setState(() {}),
+                    focusedBorder: OutlineInputBorder(
+                      borderRadius: m.brInput,
+                      borderSide: BorderSide(color: c.inputFocusBorder),
+                    ),
                   ),
+                  onChanged: (_) => setState(() {}),
                 ),
               ),
             ),
@@ -9043,52 +9022,45 @@ class _Ed2kServerSubEditorState extends State<_Ed2kServerSubEditor> {
             const SizedBox(height: 8),
             SizedBox(
               height: 100,
-              child: Localizations(
-                locale: const Locale('en'),
-                delegates: const [
-                  DefaultWidgetsLocalizations.delegate,
-                  DefaultMaterialLocalizations.delegate,
-                ],
-                child: Material(
-                  type: MaterialType.transparency,
-                  child: TextSelectionTheme(
-                    data: TextSelectionThemeData(
-                      selectionColor: m.textSelection(c.accent),
-                      cursorColor: c.accent,
-                      selectionHandleColor: c.accent,
+              child: Material(
+                type: MaterialType.transparency,
+                child: TextSelectionTheme(
+                  data: TextSelectionThemeData(
+                    selectionColor: m.textSelection(c.accent),
+                    cursorColor: c.accent,
+                    selectionHandleColor: c.accent,
+                  ),
+                  child: TextField(
+                    controller: _controller,
+                    maxLines: null,
+                    expands: true,
+                    textAlignVertical: TextAlignVertical.top,
+                    cursorColor: c.accent,
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: c.textPrimary,
+                      fontFamily: 'monospace',
+                      height: 1.5,
                     ),
-                    child: TextField(
-                      controller: _controller,
-                      maxLines: null,
-                      expands: true,
-                      textAlignVertical: TextAlignVertical.top,
-                      cursorColor: c.accent,
-                      style: TextStyle(
-                        fontSize: 12,
-                        color: c.textPrimary,
-                        fontFamily: 'monospace',
-                        height: 1.5,
+                    decoration: InputDecoration(
+                      hintText: s.ed2kServerSubPlaceholder,
+                      hintStyle: TextStyle(fontSize: 12, color: c.textMuted),
+                      hintMaxLines: 3,
+                      contentPadding: const EdgeInsets.all(10),
+                      filled: true,
+                      fillColor: c.inputBg,
+                      hoverColor: Colors.transparent,
+                      border: OutlineInputBorder(
+                        borderRadius: m.brInput,
+                        borderSide: BorderSide(color: c.inputBorder),
                       ),
-                      decoration: InputDecoration(
-                        hintText: s.ed2kServerSubPlaceholder,
-                        hintStyle: TextStyle(fontSize: 12, color: c.textMuted),
-                        hintMaxLines: 3,
-                        contentPadding: const EdgeInsets.all(10),
-                        filled: true,
-                        fillColor: c.inputBg,
-                        hoverColor: Colors.transparent,
-                        border: OutlineInputBorder(
-                          borderRadius: m.brInput,
-                          borderSide: BorderSide(color: c.inputBorder),
-                        ),
-                        enabledBorder: OutlineInputBorder(
-                          borderRadius: m.brInput,
-                          borderSide: BorderSide(color: c.inputBorder),
-                        ),
-                        focusedBorder: OutlineInputBorder(
-                          borderRadius: m.brInput,
-                          borderSide: BorderSide(color: c.inputFocusBorder),
-                        ),
+                      enabledBorder: OutlineInputBorder(
+                        borderRadius: m.brInput,
+                        borderSide: BorderSide(color: c.inputBorder),
+                      ),
+                      focusedBorder: OutlineInputBorder(
+                        borderRadius: m.brInput,
+                        borderSide: BorderSide(color: c.inputFocusBorder),
                       ),
                     ),
                   ),

--- a/lib/src/popup/popup_app.dart
+++ b/lib/src/popup/popup_app.dart
@@ -18,6 +18,7 @@ import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 
 import '../bindings/bindings.dart' show ResolvePreviewResult;
+import '../i18n/framework_localizations.dart';
 import '../i18n/locale_provider.dart';
 import '../models/download_queue.dart' show kMainQueueId;
 import '../services/file_picker_service.dart';
@@ -86,6 +87,13 @@ class _QuickPopupAppState extends State<QuickPopupApp> {
         // 同步全局 locale（currentS 供表单内无 context 场景使用）
         currentLocale = payload.locale;
         currentS = S.of(payload.locale);
+        // 弹窗每次新载荷都用 ValueKey(_epoch) 重建整棵 WidgetsApp（全新挂载
+        // 的 Localizations），非英文 shadcn 本地化走异步 deferred import；
+        // 在 setState 前预热缓存，令新树的 AppShadLocalizationsDelegate.load
+        // 同步命中，避免一帧空白。
+        await AppShadLocalizationsDelegate.warmUp(
+          frameworkLocale(payload.locale),
+        );
         setState(() {
           _payload = payload;
           _epoch++;
@@ -115,6 +123,7 @@ class _QuickPopupAppState extends State<QuickPopupApp> {
     // 与 main.dart 主窗口根组件同构：手动组合 ShadTheme + WidgetsApp
     final tokens = FluxThemeTokens.fromJson(payload.tokensJson);
     final theme = buildThemeFromTokens(tokens);
+    final fl = frameworkLocale(payload.locale);
     return LocaleScope(
       s: S.of(payload.locale),
       child: FluxThemeScope(
@@ -136,6 +145,9 @@ class _QuickPopupAppState extends State<QuickPopupApp> {
                       key: ValueKey(_epoch),
                       color: theme.colorScheme.primary,
                       debugShowCheckedModeBanner: false,
+                      locale: fl,
+                      supportedLocales: [fl],
+                      localizationsDelegates: frameworkLocalizationDelegates,
                       home: _PopupShell(
                         payload: payload,
                         formController: _formController,

--- a/lib/src/widgets/feedback_dialog.dart
+++ b/lib/src/widgets/feedback_dialog.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart'
     show
         CircularProgressIndicator,
         Colors,
-        DefaultMaterialLocalizations,
         InputDecoration,
         Material,
         MaterialType,
@@ -405,51 +404,44 @@ class _FeedbackDialogContentState extends State<_FeedbackDialogContent> {
     required AppMetrics m,
     int? maxLength,
   }) {
-    return Localizations(
-      locale: const Locale('en'),
-      delegates: const [
-        DefaultWidgetsLocalizations.delegate,
-        DefaultMaterialLocalizations.delegate,
-      ],
-      child: Material(
-        type: MaterialType.transparency,
-        child: TextSelectionTheme(
-          data: TextSelectionThemeData(
-            cursorColor: c.accent,
-            selectionColor: m.textSelection(c.accent),
-            selectionHandleColor: c.accent,
-          ),
-          child: TextField(
-            controller: controller,
-            maxLines: maxLines,
-            maxLength: maxLength,
-            buildCounter:
-                (_, {required currentLength, required isFocused, maxLength}) =>
-                    null,
-            onChanged: (_) => setState(() {}),
-            style: TextStyle(fontSize: 13, color: c.textPrimary),
-            cursorColor: c.accent,
-            decoration: InputDecoration(
-              hintText: placeholder,
-              hintStyle: TextStyle(fontSize: 13, color: c.textMuted),
-              contentPadding: const EdgeInsets.symmetric(
-                horizontal: 12,
-                vertical: 10,
-              ),
-              filled: true,
-              fillColor: c.inputBg,
-              border: OutlineInputBorder(
-                borderRadius: m.brInput,
-                borderSide: BorderSide(color: c.inputBorder),
-              ),
-              enabledBorder: OutlineInputBorder(
-                borderRadius: m.brInput,
-                borderSide: BorderSide(color: c.inputBorder),
-              ),
-              focusedBorder: OutlineInputBorder(
-                borderRadius: m.brInput,
-                borderSide: BorderSide(color: c.inputFocusBorder, width: 1.5),
-              ),
+    return Material(
+      type: MaterialType.transparency,
+      child: TextSelectionTheme(
+        data: TextSelectionThemeData(
+          cursorColor: c.accent,
+          selectionColor: m.textSelection(c.accent),
+          selectionHandleColor: c.accent,
+        ),
+        child: TextField(
+          controller: controller,
+          maxLines: maxLines,
+          maxLength: maxLength,
+          buildCounter:
+              (_, {required currentLength, required isFocused, maxLength}) =>
+                  null,
+          onChanged: (_) => setState(() {}),
+          style: TextStyle(fontSize: 13, color: c.textPrimary),
+          cursorColor: c.accent,
+          decoration: InputDecoration(
+            hintText: placeholder,
+            hintStyle: TextStyle(fontSize: 13, color: c.textMuted),
+            contentPadding: const EdgeInsets.symmetric(
+              horizontal: 12,
+              vertical: 10,
+            ),
+            filled: true,
+            fillColor: c.inputBg,
+            border: OutlineInputBorder(
+              borderRadius: m.brInput,
+              borderSide: BorderSide(color: c.inputBorder),
+            ),
+            enabledBorder: OutlineInputBorder(
+              borderRadius: m.brInput,
+              borderSide: BorderSide(color: c.inputBorder),
+            ),
+            focusedBorder: OutlineInputBorder(
+              borderRadius: m.brInput,
+              borderSide: BorderSide(color: c.inputFocusBorder, width: 1.5),
             ),
           ),
         ),

--- a/lib/src/widgets/new_download_dialog.dart
+++ b/lib/src/widgets/new_download_dialog.dart
@@ -4,10 +4,8 @@ import 'dart:io';
 import '../services/file_picker_service.dart';
 import 'package:flutter/material.dart'
     show
-        AdaptiveTextSelectionToolbar,
         CircularProgressIndicator,
         Colors,
-        DefaultMaterialLocalizations,
         InputDecoration,
         Material,
         MaterialType,
@@ -1614,69 +1612,49 @@ class _NewDownloadDialogContentState extends State<_NewDownloadDialogContent> {
                   const SizedBox(height: 6),
                   SizedBox(
                     height: 120,
-                    child: Localizations(
-                      locale: const Locale('en'),
-                      delegates: const [
-                        DefaultWidgetsLocalizations.delegate,
-                        DefaultMaterialLocalizations.delegate,
-                      ],
-                      child: Material(
-                        type: MaterialType.transparency,
-                        child: TextSelectionTheme(
-                          data: TextSelectionThemeData(
-                            selectionColor: m.textSelection(c.accent),
-                            cursorColor: c.accent,
-                            selectionHandleColor: c.accent,
+                    child: Material(
+                      type: MaterialType.transparency,
+                      child: TextSelectionTheme(
+                        data: TextSelectionThemeData(
+                          selectionColor: m.textSelection(c.accent),
+                          cursorColor: c.accent,
+                          selectionHandleColor: c.accent,
+                        ),
+                        child: TextField(
+                          controller: _urlController,
+                          focusNode: _urlFocusNode,
+                          autofocus: true,
+                          maxLines: null,
+                          expands: true,
+                          textAlignVertical: TextAlignVertical.top,
+                          cursorColor: c.accent,
+                          style: TextStyle(
+                            fontSize: 13,
+                            color: c.textPrimary,
                           ),
-                          child: TextField(
-                            controller: _urlController,
-                            focusNode: _urlFocusNode,
-                            autofocus: true,
-                            maxLines: null,
-                            expands: true,
-                            textAlignVertical: TextAlignVertical.top,
-                            cursorColor: c.accent,
-                            style: TextStyle(
-                              fontSize: 13,
-                              color: c.textPrimary,
+                          decoration: InputDecoration(
+                            hintText: s.batchUrlPlaceholder,
+                            hintStyle: TextStyle(
+                              fontSize: 12.5,
+                              color: c.textMuted,
                             ),
-                            contextMenuBuilder: (context, editableTextState) {
-                              return Localizations(
-                                locale: const Locale('en'),
-                                delegates: const [
-                                  DefaultWidgetsLocalizations.delegate,
-                                  DefaultMaterialLocalizations.delegate,
-                                ],
-                                child:
-                                    AdaptiveTextSelectionToolbar.editableText(
-                                      editableTextState: editableTextState,
-                                    ),
-                              );
-                            },
-                            decoration: InputDecoration(
-                              hintText: s.batchUrlPlaceholder,
-                              hintStyle: TextStyle(
-                                fontSize: 12.5,
-                                color: c.textMuted,
-                              ),
-                              hintMaxLines: 5,
-                              contentPadding: const EdgeInsets.all(10),
-                              filled: true,
-                              fillColor: c.inputBg,
-                              hoverColor: Colors.transparent,
-                              border: OutlineInputBorder(
-                                borderRadius: m.brInput,
-                                borderSide: BorderSide(color: c.inputBorder),
-                              ),
-                              enabledBorder: OutlineInputBorder(
-                                borderRadius: m.brInput,
-                                borderSide: BorderSide(color: c.inputBorder),
-                              ),
-                              focusedBorder: OutlineInputBorder(
-                                borderRadius: m.brInput,
-                                borderSide: BorderSide(
-                                  color: c.inputFocusBorder,
-                                ),
+                            hintMaxLines: 5,
+                            contentPadding: const EdgeInsets.all(10),
+                            filled: true,
+                            fillColor: c.inputBg,
+                            hoverColor: Colors.transparent,
+                            border: OutlineInputBorder(
+                              borderRadius: m.brInput,
+                              borderSide: BorderSide(color: c.inputBorder),
+                            ),
+                            enabledBorder: OutlineInputBorder(
+                              borderRadius: m.brInput,
+                              borderSide: BorderSide(color: c.inputBorder),
+                            ),
+                            focusedBorder: OutlineInputBorder(
+                              borderRadius: m.brInput,
+                              borderSide: BorderSide(
+                                color: c.inputFocusBorder,
                               ),
                             ),
                           ),

--- a/lib/src/widgets/quick_download_form.dart
+++ b/lib/src/widgets/quick_download_form.dart
@@ -13,10 +13,8 @@ import 'dart:async';
 
 import 'package:flutter/material.dart'
     show
-        AdaptiveTextSelectionToolbar,
         CircularProgressIndicator,
         Colors,
-        DefaultMaterialLocalizations,
         InputDecoration,
         Material,
         MaterialType,
@@ -736,59 +734,40 @@ class _QuickDownloadFormState extends State<QuickDownloadForm> {
           const SizedBox(height: 6),
           // 自适应高度：默认 2 行紧凑，随内容增高到 6 行后内部滚动，
           // 避免单条链接时大片留白（小窗高度跟随内容，同步收窄）
-          Localizations(
-            locale: const Locale('en'),
-            delegates: const [
-              DefaultWidgetsLocalizations.delegate,
-              DefaultMaterialLocalizations.delegate,
-            ],
-            child: Material(
-              type: MaterialType.transparency,
-              child: TextSelectionTheme(
-                data: TextSelectionThemeData(
-                  selectionColor: m.textSelection(c.accent),
-                  cursorColor: c.accent,
-                  selectionHandleColor: c.accent,
-                ),
-                child: TextField(
-                  controller: _urlController,
-                  focusNode: _urlFocusNode,
-                  minLines: 2,
-                  maxLines: 6,
-                  cursorColor: c.accent,
-                  style: TextStyle(fontSize: 13, color: c.textPrimary),
-                  contextMenuBuilder: (context, editableTextState) {
-                    return Localizations(
-                      locale: const Locale('en'),
-                      delegates: const [
-                        DefaultWidgetsLocalizations.delegate,
-                        DefaultMaterialLocalizations.delegate,
-                      ],
-                      child: AdaptiveTextSelectionToolbar.editableText(
-                        editableTextState: editableTextState,
-                      ),
-                    );
-                  },
-                  decoration: InputDecoration(
-                    hintText: s.batchUrlPlaceholder,
-                    hintStyle: TextStyle(fontSize: 12.5, color: c.textMuted),
-                    hintMaxLines: 5,
-                    contentPadding: const EdgeInsets.all(10),
-                    filled: true,
-                    fillColor: c.inputBg,
-                    hoverColor: Colors.transparent,
-                    border: OutlineInputBorder(
-                      borderRadius: m.brInput,
-                      borderSide: BorderSide(color: c.inputBorder),
-                    ),
-                    enabledBorder: OutlineInputBorder(
-                      borderRadius: m.brInput,
-                      borderSide: BorderSide(color: c.inputBorder),
-                    ),
-                    focusedBorder: OutlineInputBorder(
-                      borderRadius: m.brInput,
-                      borderSide: BorderSide(color: c.inputFocusBorder),
-                    ),
+          Material(
+            type: MaterialType.transparency,
+            child: TextSelectionTheme(
+              data: TextSelectionThemeData(
+                selectionColor: m.textSelection(c.accent),
+                cursorColor: c.accent,
+                selectionHandleColor: c.accent,
+              ),
+              child: TextField(
+                controller: _urlController,
+                focusNode: _urlFocusNode,
+                minLines: 2,
+                maxLines: 6,
+                cursorColor: c.accent,
+                style: TextStyle(fontSize: 13, color: c.textPrimary),
+                decoration: InputDecoration(
+                  hintText: s.batchUrlPlaceholder,
+                  hintStyle: TextStyle(fontSize: 12.5, color: c.textMuted),
+                  hintMaxLines: 5,
+                  contentPadding: const EdgeInsets.all(10),
+                  filled: true,
+                  fillColor: c.inputBg,
+                  hoverColor: Colors.transparent,
+                  border: OutlineInputBorder(
+                    borderRadius: m.brInput,
+                    borderSide: BorderSide(color: c.inputBorder),
+                  ),
+                  enabledBorder: OutlineInputBorder(
+                    borderRadius: m.brInput,
+                    borderSide: BorderSide(color: c.inputBorder),
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: m.brInput,
+                    borderSide: BorderSide(color: c.inputFocusBorder),
                   ),
                 ),
               ),

--- a/lib/src/widgets/thread_selector.dart
+++ b/lib/src/widgets/thread_selector.dart
@@ -5,13 +5,7 @@
 library;
 
 import 'package:flutter/material.dart'
-    show
-        DefaultMaterialLocalizations,
-        InputBorder,
-        InputDecoration,
-        Material,
-        MaterialType,
-        TextField;
+    show InputBorder, InputDecoration, Material, MaterialType, TextField;
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
@@ -214,36 +208,29 @@ class _ThreadSelectorState extends State<ThreadSelector> {
           children: [
             // 可编辑输入区
             Expanded(
-              child: Localizations(
-                locale: const Locale('en'),
-                delegates: const [
-                  DefaultWidgetsLocalizations.delegate,
-                  DefaultMaterialLocalizations.delegate,
-                ],
-                child: Material(
-                  type: MaterialType.transparency,
-                  child: TextField(
-                    controller: _ctrl,
-                    focusNode: _focusNode,
-                    style: TextStyle(fontSize: 14, color: c.textPrimary),
-                    decoration: InputDecoration(
-                      border: InputBorder.none,
-                      isDense: true,
-                      contentPadding: const EdgeInsets.symmetric(
-                        horizontal: 12,
-                        vertical: 9,
-                      ),
-                      hintText: s.customThreadsHint,
-                      hintStyle: TextStyle(fontSize: 14, color: c.textMuted),
+              child: Material(
+                type: MaterialType.transparency,
+                child: TextField(
+                  controller: _ctrl,
+                  focusNode: _focusNode,
+                  style: TextStyle(fontSize: 14, color: c.textPrimary),
+                  decoration: InputDecoration(
+                    border: InputBorder.none,
+                    isDense: true,
+                    contentPadding: const EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: 9,
                     ),
-                    inputFormatters: [
-                      FilteringTextInputFormatter.digitsOnly,
-                      LengthLimitingTextInputFormatter(3),
-                    ],
-                    textInputAction: TextInputAction.done,
-                    onChanged: _onInputChanged,
-                    onSubmitted: (_) => _focusNode.unfocus(),
+                    hintText: s.customThreadsHint,
+                    hintStyle: TextStyle(fontSize: 14, color: c.textMuted),
                   ),
+                  inputFormatters: [
+                    FilteringTextInputFormatter.digitsOnly,
+                    LengthLimitingTextInputFormatter(3),
+                  ],
+                  textInputAction: TextInputAction.done,
+                  onChanged: _onInputChanged,
+                  onSubmitted: (_) => _focusNode.unfocus(),
                 ),
               ),
             ),

--- a/test/framework_localizations_test.dart
+++ b/test/framework_localizations_test.dart
@@ -1,0 +1,56 @@
+// 应用级本地化装配回归测试（issue #515）：应用根是裸 WidgetsApp，Material
+// TextField 与 shadcn ShadInput 的右键菜单/选区工具栏各自依赖
+// MaterialLocalizations / ShadLocalizations，此前树上没有对应 delegate，
+// ShadInput 一侧还会悄悄回退英文（不抛异常，容易被忽略）。
+import 'package:flutter/material.dart' show MaterialLocalizations;
+import 'package:flutter/widgets.dart';
+import 'package:flutter/foundation.dart' show SynchronousFuture;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+import 'package:flux_down/src/i18n/framework_localizations.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('frameworkLocale 解析 i18n 代码为 Material 本地化实际支持的 Locale', () {
+    expect(frameworkLocale('zh'), const Locale('zh'));
+    expect(frameworkLocale('xx'), const Locale('en'));
+    expect(frameworkLocale(''), const Locale('en'));
+    expect(frameworkLocale('zh-hant').scriptCode, 'Hant');
+  });
+
+  testWidgets('中文 WidgetsApp 根：Material 与 shadcn 本地化文案都跟随中文', (
+    tester,
+  ) async {
+    final locale = frameworkLocale('zh');
+    late BuildContext capturedContext;
+
+    await tester.pumpWidget(
+      WidgetsApp(
+        color: const Color(0xFF000000),
+        locale: locale,
+        supportedLocales: [locale],
+        localizationsDelegates: frameworkLocalizationDelegates,
+        builder: (context, child) {
+          capturedContext = context;
+          return const SizedBox.shrink();
+        },
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(MaterialLocalizations.of(capturedContext).copyButtonLabel, '复制');
+    expect(ShadLocalizations.of(capturedContext).input.copy, '复制');
+  });
+
+  test('预热后的语言在 AppShadLocalizationsDelegate.load 中同步命中缓存', () async {
+    const locale = Locale('zh');
+    await AppShadLocalizationsDelegate.warmUp(locale);
+
+    final future = AppShadLocalizationsDelegate.delegate.load(locale);
+    expect(future, isA<SynchronousFuture<ShadLocalizationsData>>());
+    expect((await future).input.copy, '复制');
+  });
+}

--- a/test/quick_download_form_append_test.dart
+++ b/test/quick_download_form_append_test.dart
@@ -13,6 +13,7 @@
 import 'package:flutter/material.dart' show TextField;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flux_down/src/i18n/framework_localizations.dart';
 import 'package:flux_down/src/theme/app_theme.dart';
 import 'package:flux_down/src/theme/flux_theme_tokens.dart';
 import 'package:flux_down/src/widgets/quick_download_form.dart';
@@ -65,6 +66,7 @@ Widget _wrapForm(QuickDownloadForm form) {
               child: WidgetsApp(
                 color: theme.colorScheme.primary,
                 debugShowCheckedModeBanner: false,
+                localizationsDelegates: frameworkLocalizationDelegates,
                 home: form,
                 pageRouteBuilder: <T>(
                   RouteSettings settings,

--- a/test/quick_download_form_site_auth_test.dart
+++ b/test/quick_download_form_site_auth_test.dart
@@ -10,6 +10,7 @@
 import 'package:flutter/material.dart' show TextField;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flux_down/src/i18n/framework_localizations.dart';
 import 'package:flux_down/src/theme/app_theme.dart';
 import 'package:flux_down/src/theme/flux_theme_tokens.dart';
 import 'package:flux_down/src/widgets/quick_download_form.dart';
@@ -59,6 +60,7 @@ Widget _wrapForm(QuickDownloadForm form) {
               child: WidgetsApp(
                 color: theme.colorScheme.primary,
                 debugShowCheckedModeBanner: false,
+                localizationsDelegates: frameworkLocalizationDelegates,
                 home: SingleChildScrollView(child: form),
                 pageRouteBuilder: <T>(
                   RouteSettings settings,

--- a/test/quick_download_form_validation_test.dart
+++ b/test/quick_download_form_validation_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 
+import 'package:flux_down/src/i18n/framework_localizations.dart';
 import 'package:flux_down/src/i18n/locale_provider.dart';
 import 'package:flux_down/src/theme/app_theme.dart';
 import 'package:flux_down/src/theme/flux_theme_tokens.dart';
@@ -49,6 +50,7 @@ Widget _wrapForm(QuickDownloadForm form) {
               child: WidgetsApp(
                 color: theme.colorScheme.primary,
                 debugShowCheckedModeBanner: false,
+                localizationsDelegates: frameworkLocalizationDelegates,
                 home: form,
                 pageRouteBuilder:
                     <T>(RouteSettings settings, WidgetBuilder builder) {


### PR DESCRIPTION
## 问题
界面语言为中文时，输入框右键菜单 / 选区工具栏（剪切/复制/粘贴/全选）固定英文。

## 根因
应用根是裸 `WidgetsApp`（绕过 `ShadApp`），未挂任何 `localizationsDelegates`：
- Material `TextField` 需要 `MaterialLocalizations`，各处用 `Localizations(locale: Locale('en'))` 手写包装，永久锁死英文（10 处）；
- shadcn `ShadInput`（搜索框等大多数输入框）菜单经 `ShadLocalizations.of` 取文案，delegate 缺失时**静默回退英文**。

## 修复
- 新增 `lib/src/i18n/framework_localizations.dart`：`frameworkLocale()`（i18n 代码 → Material 支持的 Locale，不支持回退 en）、`AppShadLocalizationsDelegate`（同步缓存 + `warmUp`）、`frameworkLocalizationDelegates`。
- 三个 `WidgetsApp` 根（主窗口 / 移动端 / 快速下载小窗）统一挂载；启动与小窗 `setPayload` 前预热，避免 shadcn deferred import 异步加载导致新挂载树闪一帧空白。
- 删除全部 10 处手写 `Localizations` 包装与冗余 `contextMenuBuilder`（净删 60 行）。

## 验证
- `flutter analyze` 改动文件 0 issue
- 全量 `flutter test` 586 passed
- 新增 `test/framework_localizations_test.dart`：中文根下 Material 与 shadcn 文案均为「复制」；预热后 `load` 为 `SynchronousFuture`

Closes #515