### PR TITLE
feat(ui): 标题栏「新建下载」按钮可隐藏 (#582)

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -705,6 +705,8 @@
   "apiServiceCorsAllowAllHelp": "The local service sends no Access-Control-Allow-Origin by default, so a cross-origin fetch from a web page is blocked at the CORS preflight. Some sites probe for an aria2 service that way and therefore cannot detect FluxDown.\nWith this on, every origin gets CORS allow headers — the equivalent of aria2's --rpc-allow-origin-all.\nCost: any web page can probe this port and submit download links. Still in effect: takeover and aria2 submissions raise the confirmation dialog; the management API and MCP require the token.",
   "titlebarButtons": "Titlebar Buttons",
   "titlebarButtonsDesc": "Choose which tool buttons to show in the titlebar; right-click a button to hide it",
+  "showTitlebarNewDownload": "New Download Button",
+  "showTitlebarNewDownloadDesc": "Show the New Download button in the titlebar; right-click the task list to create a download when hidden",
   "showTitlebarPauseAll": "Pause All Button",
   "showTitlebarPauseAllDesc": "Show pause all button in the titlebar",
   "showTitlebarResumeAll": "Resume All Button",

--- a/assets/i18n/zh.json
+++ b/assets/i18n/zh.json
@@ -705,6 +705,8 @@
   "apiServiceCorsAllowAllHelp": "本机服务默认不返回 Access-Control-Allow-Origin，网页发来的跨域 fetch 在预检阶段就被浏览器拦下。部分网站用 fetch 探测 aria2 服务，因此识别不到 FluxDown。\n开启后对所有来源返回 CORS 放行头，等同 aria2 的 --rpc-allow-origin-all。\n代价：任意网页都能探测本机端口并提交下载链接。仍生效的防护：接管与 aria2 提交会弹确认框，管理 API 与 MCP 强制校验令牌。",
   "titlebarButtons": "标题栏按钮",
   "titlebarButtonsDesc": "选择在标题栏显示哪些工具按钮，也可右键按钮直接隐藏",
+  "showTitlebarNewDownload": "新建下载按钮",
+  "showTitlebarNewDownloadDesc": "在标题栏显示新建下载按钮；隐藏后可在任务列表右键新建下载",
   "showTitlebarPauseAll": "全部暂停按钮",
   "showTitlebarPauseAllDesc": "在标题栏显示全部暂停按钮",
   "showTitlebarResumeAll": "全部恢复按钮",

--- a/lib/src/i18n/translations.dart
+++ b/lib/src/i18n/translations.dart
@@ -969,6 +969,8 @@ class S {
   // 标题栏按钮
   String get titlebarButtons => _r('titlebarButtons');
   String get titlebarButtonsDesc => _r('titlebarButtonsDesc');
+  String get showTitlebarNewDownload => _r('showTitlebarNewDownload');
+  String get showTitlebarNewDownloadDesc => _r('showTitlebarNewDownloadDesc');
   String get showTitlebarPauseAll => _r('showTitlebarPauseAll');
   String get showTitlebarPauseAllDesc => _r('showTitlebarPauseAllDesc');
   String get showTitlebarResumeAll => _r('showTitlebarResumeAll');

--- a/lib/src/models/settings_provider.dart
+++ b/lib/src/models/settings_provider.dart
@@ -69,6 +69,9 @@ class SettingsProvider extends ChangeNotifier {
   bool? _showSidebarDevice;
 
   // 标题栏工具按钮显示设置
+  // 本地设置，不进入云同步目录：同步键目录 v1 已冻结（三方契约），
+  // 新增键需三方契约 v2。
+  bool _showTitlebarNewDownload = true; // 新建下载按钮
   bool _showTitlebarPauseAll = true; // 全部暂停按钮
   bool _showTitlebarResumeAll = true; // 全部恢复按钮
   bool _showTitlebarSettings = true; // 设置按钮
@@ -315,6 +318,7 @@ class SettingsProvider extends ChangeNotifier {
       _showSidebarDevice ?? hasAnyDevice;
 
   // 标题栏工具按钮 Getters
+  bool get showTitlebarNewDownload => _showTitlebarNewDownload;
   bool get showTitlebarPauseAll => _showTitlebarPauseAll;
   bool get showTitlebarResumeAll => _showTitlebarResumeAll;
   bool get showTitlebarSettings => _showTitlebarSettings;
@@ -809,6 +813,13 @@ class SettingsProvider extends ChangeNotifier {
   }
 
   // 标题栏工具按钮 Setters
+
+  void setShowTitlebarNewDownload(bool value) {
+    if (_showTitlebarNewDownload == value) return;
+    _showTitlebarNewDownload = value;
+    notifyListeners();
+    _saveToRust('show_titlebar_new_download', value.toString());
+  }
 
   void setShowTitlebarPauseAll(bool value) {
     if (_showTitlebarPauseAll == value) return;
@@ -2095,6 +2106,8 @@ class SettingsProvider extends ChangeNotifier {
               : entry.value == 'false'
               ? false
               : null;
+        case 'show_titlebar_new_download':
+          _showTitlebarNewDownload = entry.value != 'false';
         case 'show_titlebar_pause_all':
           _showTitlebarPauseAll = entry.value != 'false';
         case 'show_titlebar_resume_all':

--- a/lib/src/pages/settings_page.dart
+++ b/lib/src/pages/settings_page.dart
@@ -2300,6 +2300,15 @@ class _GeneralContent extends StatelessWidget {
               subtitle: s.titlebarButtonsDesc,
               children: [
                 _SettingRow(
+                  label: s.showTitlebarNewDownload,
+                  description: s.showTitlebarNewDownloadDesc,
+                  child: ShadSwitch(
+                    value: settingsProvider.showTitlebarNewDownload,
+                    onChanged: (v) =>
+                        settingsProvider.setShowTitlebarNewDownload(v),
+                  ),
+                ),
+                _SettingRow(
                   label: s.showTitlebarPauseAll,
                   description: s.showTitlebarPauseAllDesc,
                   child: ShadSwitch(

--- a/lib/src/widgets/header_bar.dart
+++ b/lib/src/widgets/header_bar.dart
@@ -277,30 +277,7 @@ class HeaderBarState extends State<HeaderBar> {
         ),
         child: Row(
           children: [
-            // New download button
-            ShadButton(
-              onPressed: widget.onNewDownload,
-              height: 30,
-              padding: const EdgeInsets.symmetric(horizontal: 12),
-              backgroundColor: c.accent,
-              hoverBackgroundColor: c.accentHover,
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  const Icon(LucideIcons.plus, size: 14, color: Colors.white),
-                  const SizedBox(width: 6),
-                  Text(
-                    s.newDownload,
-                    style: const TextStyle(
-                      fontSize: 13,
-                      color: Colors.white,
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            const SizedBox(width: 12),
+            _buildNewDownloadButton(context, c, s),
             // Search with overlay dropdown
             Flexible(
               child: ConstrainedBox(
@@ -389,6 +366,58 @@ class HeaderBarState extends State<HeaderBar> {
           ],
         ),
       ),
+    );
+  }
+
+  /// 新建下载按钮：可在设置中关闭，隐藏后仍可通过任务列表右键菜单、
+  /// 应用菜单或快捷键新建下载；右键此按钮可直接隐藏。
+  Widget _buildNewDownloadButton(BuildContext context, AppColors c, S s) {
+    Widget buildButton(SettingsProvider? settings) {
+      if (!(settings?.showTitlebarNewDownload ?? true)) {
+        return const SizedBox.shrink();
+      }
+      return Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          ShadButton(
+            onPressed: widget.onNewDownload,
+            height: 30,
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            backgroundColor: c.accent,
+            hoverBackgroundColor: c.accentHover,
+            onSecondaryTapUp: settings == null
+                ? null
+                : (d) => _showHideButtonMenu(
+                    context,
+                    d.globalPosition,
+                    () => settings.setShowTitlebarNewDownload(false),
+                  ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(LucideIcons.plus, size: 14, color: Colors.white),
+                const SizedBox(width: 6),
+                Text(
+                  s.newDownload,
+                  style: const TextStyle(
+                    fontSize: 13,
+                    color: Colors.white,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 12),
+        ],
+      );
+    }
+
+    final settings = SettingsProvider.globalInstance;
+    if (settings == null) return buildButton(null);
+    return ListenableBuilder(
+      listenable: settings,
+      builder: (context, _) => buildButton(settings),
     );
   }
 
@@ -768,6 +797,27 @@ class _WindowButtonState extends State<_WindowButton> {
   }
 }
 
+/// 标题栏按钮的「隐藏」右键菜单，供各标题栏按钮组件复用。
+void _showHideButtonMenu(
+  BuildContext context,
+  Offset position,
+  VoidCallback onHide,
+) {
+  final c = AppColors.of(context);
+  showContextMenu(
+    context,
+    position,
+    items: [
+      ContextMenuItem(
+        icon: LucideIcons.eyeOff,
+        label: LocaleScope.of(context).hideButton,
+        color: c.textSecondary,
+        action: onHide,
+      ),
+    ],
+  );
+}
+
 /// 标题栏工具按钮组（全部暂停/全部恢复/设置/主题切换）。
 ///
 /// 每个按钮可在「设置 → 通用 → 标题栏按钮」中开关显示，
@@ -793,26 +843,6 @@ class _TitlebarToolButtons extends StatelessWidget {
     );
   }
 
-  void _showHideMenu(
-    BuildContext context,
-    Offset position,
-    VoidCallback onHide,
-  ) {
-    final c = AppColors.of(context);
-    showContextMenu(
-      context,
-      position,
-      items: [
-        ContextMenuItem(
-          icon: LucideIcons.eyeOff,
-          label: LocaleScope.of(context).hideButton,
-          color: c.textSecondary,
-          action: onHide,
-        ),
-      ],
-    );
-  }
-
   Widget _buildRow(BuildContext context, SettingsProvider? settings) {
     final s = LocaleScope.of(context);
     final themeProvider = FluxDownApp.of(context);
@@ -831,7 +861,7 @@ class _TitlebarToolButtons extends StatelessWidget {
             iconSize: 16,
             onSecondaryTapUp: settings == null
                 ? null
-                : (d) => _showHideMenu(
+                : (d) => _showHideButtonMenu(
                     context,
                     d.globalPosition,
                     () => settings.setShowTitlebarPauseAll(false),
@@ -845,7 +875,7 @@ class _TitlebarToolButtons extends StatelessWidget {
             iconSize: 16,
             onSecondaryTapUp: settings == null
                 ? null
-                : (d) => _showHideMenu(
+                : (d) => _showHideButtonMenu(
                     context,
                     d.globalPosition,
                     () => settings.setShowTitlebarResumeAll(false),
@@ -860,7 +890,7 @@ class _TitlebarToolButtons extends StatelessWidget {
             isActive: isSettingsActive,
             onSecondaryTapUp: settings == null
                 ? null
-                : (d) => _showHideMenu(
+                : (d) => _showHideButtonMenu(
                     context,
                     d.globalPosition,
                     () => settings.setShowTitlebarSettings(false),
@@ -878,7 +908,7 @@ class _TitlebarToolButtons extends StatelessWidget {
             iconSize: 15,
             onSecondaryTapUp: settings == null
                 ? null
-                : (d) => _showHideMenu(
+                : (d) => _showHideButtonMenu(
                     context,
                     d.globalPosition,
                     () => settings.setShowTitlebarTheme(false),


### PR DESCRIPTION
## 需求
极简用户希望隐藏标题栏「新建下载」按钮；任务列表右键 / ⌘N / 应用菜单仍可新建下载。

## 实现
严格镜像现有 `show_titlebar_pause_all` 等模式：
- `settings_provider.dart`：`show_titlebar_new_download`（config 表，默认 true，老用户无感）
- `header_bar.dart`：`ListenableBuilder` 实时隐藏；`ShadButton.onSecondaryTapUp` 右键「隐藏按钮」；`_showHideMenu` 提为文件级函数复用
- 设置页「标题栏按钮」组首行开关；en/zh 文案

设备本地设置，**不进入**云同步目录（同步键目录 v1 为三方冻结契约，需 v2 才可新增键）。GPUI 侧标题栏组暂未同步此开关。

## 验证
- `flutter analyze` 改动文件 0 issue
- `flutter test test/sync_catalog_test.dart` 51 键断言不变，通过

Closes #582