### PR TITLE
fix(extension): issue#640修复-增加 blob/data 下载不支持接管的提示

### DIFF
--- a/fluxDown/entrypoints/options/index.html
+++ b/fluxDown/entrypoints/options/index.html
@@ -199,6 +199,13 @@
           <div class="opt-row-info">
             <div class="opt-row-title" data-i18n="settings.interceptMode">Intercept Mode</div>
             <div class="opt-row-desc" id="modeHint"></div>
+            <div class="opt-row-desc opt-row-note">
+              <svg class="opt-row-note-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-width="2" />
+                <path d="M12 7v5m0 4h.01" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+              </svg>
+              <span data-i18n="settings.localDownloadHint">Locally generated blob:/data: files are not supported and use the browser download</span>
+            </div>
           </div>
           <div class="opt-row-control">
             <select id="interceptModeSelect">

--- a/fluxDown/entrypoints/options/options.css
+++ b/fluxDown/entrypoints/options/options.css
@@ -125,6 +125,21 @@ body {
   color: var(--text-secondary);
 }
 
+.opt-row-note {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-top: 8px;
+  color: #3b82f6;
+  white-space: nowrap;
+}
+
+.opt-row-note-icon {
+  flex: 0 0 16px;
+  width: 16px;
+  height: 16px;
+}
+
 .opt-row-control {
   flex: 1 1 320px;
   max-width: 380px;

--- a/fluxDown/utils/locales/en.ts
+++ b/fluxDown/utils/locales/en.ts
@@ -29,6 +29,8 @@ const en: Record<MessageKey, string> = {
   "settings.modeAll": "Intercept All",
   "settings.hintSmart": "Smart detection based on filename, type, and size",
   "settings.hintAll": "Intercept all downloads (except excluded domains)",
+  "settings.localDownloadHint":
+    "Locally generated blob:/data: files are not supported and use the browser download",
   "settings.minFileSize": "Min File Size",
   "settings.sizeNoLimit": "No limit",
   "settings.interceptMagnet": "Take Over Magnet Links",

--- a/fluxDown/utils/locales/zh-CN.ts
+++ b/fluxDown/utils/locales/zh-CN.ts
@@ -27,6 +27,8 @@ const zhCN = {
   "settings.modeAll": "拦截所有",
   "settings.hintSmart": "综合文件名、类型、大小智能判断",
   "settings.hintAll": "拦截所有下载（除排除域名外）",
+  "settings.localDownloadHint":
+    "网页本地生成的 blob:/data: 文件不支持接管，将由浏览器下载",
   "settings.minFileSize": "最小文件大小",
   "settings.sizeNoLimit": "不限",
   "settings.interceptMagnet": "接管磁力链接",


### PR DESCRIPTION
- 在拦截模式设置中增加蓝色感叹号提示图标
- 说明网页本地生成的 blob:/data: 文件无法由 FluxDown 接管
- 同步中英文文案
<img width="845" height="162" alt="image" src="https://github.com/user-attachments/assets/4fe44b7e-98fe-4428-a832-d7242f7a2823" />
